### PR TITLE
feat: add PSR-4 autoloading

### DIFF
--- a/includes/index.php
+++ b/includes/index.php
@@ -1,2 +1,0 @@
-<?php
-//I have known the silence of the stars and of the sea

--- a/src/Core/AudioRecorder.php
+++ b/src/Core/AudioRecorder.php
@@ -1,0 +1,83 @@
+<?php
+namespace Starisian\src\Core;
+
+use Starisian\src\Includes\StarmusAudioSubmissionHandler;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+final class AudioRecorder {
+    const VERSION = '0.5.0';
+    const MINIMUM_PHP_VERSION = '7.2';
+    const MINIMUM_WP_VERSION = '5.2';
+
+    private static ?AudioRecorder $instance = null;
+    private string $plugin_path;
+    private string $plugin_url;
+    private ?StarmusAudioSubmissionHandler $StarmusHandler = null;
+
+    private function __construct() {
+        $this->plugin_path = STARMUS_PATH;
+        $this->plugin_url  = STARMUS_URL;
+
+        if ( ! $this->check_compatibility() ) {
+            add_action( 'admin_notices', [ $this, 'admin_notice_compatibility' ] );
+            return;
+        }
+
+        if ( ! isset( $this->StarmusHandler ) ) {
+            $this->StarmusHandler = new StarmusAudioSubmissionHandler();
+        }
+    }
+
+    public static function get_instance(): AudioRecorder {
+        if ( null === self::$instance ) {
+            self::$instance = new self();
+        }
+        return self::$instance;
+    }
+
+    private function check_compatibility(): bool {
+        if ( version_compare( PHP_VERSION, self::MINIMUM_PHP_VERSION, '<' ) ) {
+            return false;
+        }
+
+        global $wp_version;
+        if ( version_compare( $wp_version, self::MINIMUM_WP_VERSION, '<' ) ) {
+            return false;
+        }
+
+        return true;
+    }
+
+    public function admin_notice_compatibility(): void {
+        echo '<div class="notice notice-error"><p>';
+        if ( version_compare( PHP_VERSION, self::MINIMUM_PHP_VERSION, '<' ) ) {
+            echo esc_html__( 'Starmus Audio Recorder requires PHP version ' . self::MINIMUM_PHP_VERSION . ' or higher.', 'starmus-audio-recorder' ) . '<br>';
+        }
+        if ( version_compare( $GLOBALS['wp_version'], self::MINIMUM_WP_VERSION, '<' ) ) {
+            echo esc_html__( 'Starmus Audio Recorder requires WordPress version ' . self::MINIMUM_WP_VERSION . ' or higher.', 'starmus-audio-recorder' );
+        }
+        echo '</p></div>';
+    }
+
+    public static function starmus_run(): void {
+        if ( ! isset( $GLOBALS['Starisian\\AudioRecorder'] ) || ! $GLOBALS['Starisian\\AudioRecorder'] instanceof self ) {
+            $GLOBALS['Starisian\\AudioRecorder'] = self::get_instance();
+        }
+    }
+
+    public static function starmus_activate(): void {
+        flush_rewrite_rules();
+    }
+
+    public static function starmus_deactivate(): void {
+        flush_rewrite_rules();
+    }
+
+    public static function starmus_uninstall(): void {
+        // Optional cleanup logic for uninstall.
+        // Example: delete_option('starmus_audio_recorder_settings');
+    }
+}

--- a/src/Includes/StarmusAudioSubmissionHandler.php
+++ b/src/Includes/StarmusAudioSubmissionHandler.php
@@ -1,12 +1,10 @@
 <?php
-namespace Starmus\includes;
+namespace Starisian\src\Includes;
 
 // exit if access directly
 if (!defined('ABSPATH')) {
     exit;
 }
-
-if (!class_exists('Starmus_Audio_Submission_Handler')) {
 
     class StarmusAudioSubmissionHandler
     {
@@ -424,7 +422,3 @@ if (!class_exists('Starmus_Audio_Submission_Handler')) {
         }
     }
 
-    // Register the audio submission handler
-    // Register in main class file :: new StarmusAudioSubmissionHandler(); // Fixed class name
-
-}

--- a/src/includes/Autoloader.php
+++ b/src/includes/Autoloader.php
@@ -1,0 +1,26 @@
+<?php
+namespace Starisian\src\Includes;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class Autoloader {
+    public static function register(): void {
+        spl_autoload_register( [ __CLASS__, 'autoload' ] );
+    }
+
+    private static function autoload( string $class ): void {
+        $prefix = 'Starisian\\src\\';
+        $base_dir = dirname( __DIR__ ) . '/';
+        $len = strlen( $prefix );
+        if ( strncmp( $prefix, $class, $len ) !== 0 ) {
+            return;
+        }
+        $relative_class = substr( $class, $len );
+        $file = $base_dir . str_replace( '\\', '/', $relative_class ) . '.php';
+        if ( file_exists( $file ) ) {
+            require $file;
+        }
+    }
+}

--- a/starmus-audio-recorder.php
+++ b/starmus-audio-recorder.php
@@ -1,5 +1,4 @@
 <?php
-namespace Starmus;
 /**
  * STARISIAN TECHNOLOGIES CONFIDENTIAL
  * © 2023–2025 Starisian Technologies. All Rights Reserved.
@@ -44,133 +43,11 @@ if ( ! defined( 'STARMUS_VERSION' ) ) {
 	define( 'STARMUS_VERSION', '0.5.0' );
 }
 
+require_once __DIR__ . '/src/includes/Autoloader.php';
+Starisian\src\Includes\Autoloader::register();
 
-use Starmus\includes\StarmusAudioRecorderHandler;
+register_activation_hook( __FILE__, [ 'Starisian\\src\\Core\\AudioRecorder', 'starmus_activate' ] );
+register_deactivation_hook( __FILE__, [ 'Starisian\\src\\Core\\AudioRecorder', 'starmus_deactivate' ] );
+register_uninstall_hook( __FILE__, [ 'Starisian\\src\\Core\\AudioRecorder', 'starmus_uninstall' ] );
 
-/**
- * Class AudioRecorder
- *
- * Handles audio recording functionalities for the Starmus Audio Recorder WordPress plugin.
- * This class is declared as final and cannot be extended.
- *
- * @package StarmusAudioRecorder
- */
-final class AudioRecorder {
-	/**
-	 * Plugin version constant.
-	 *
-	 * Represents the current version of the Starmus Audio Recorder plugin.
-	 *
-	 * @var string
-	 */
-	const VERSION = '0.5.0';
-	const MINIMUM_PHP_VERSION = '7.2';
-	const MINIMUM_WP_VERSION = '5.2';
-
-	private static $instance = null;
-	private $plugin_path;
-	private $plugin_url;
-	private $StarmusHandler = null;
-
-	private function __construct() {
-		$this->plugin_path = STARMUS_PATH;
-		$this->plugin_url  = STARMUS_URL;
-
-		if ( ! $this->check_compatibility() ) {
-			add_action( 'admin_notices', array( $this, 'admin_notice_compatibility' ) );
-			return;
-		}
-
-		$this->load_dependencies();
-		// add the handler
-		if ( ! isset( $this->StarmusHandler ) ) {
-			$this->StarmusHandler = new \Starmus\includes\StarmusAudioSubmissionHandler();
-		}
-	}
-
-	/**
-	 * Retrieves the singleton instance of the AudioRecorder class.
-	 *
-	 * @return AudioRecorder The single instance of the AudioRecorder.
-	 */
-	public static function get_instance(): AudioRecorder {
-		if ( null === self::$instance ) {
-			self::$instance = new self();
-		}
-		return self::$instance;
-	}
-
-	private function check_compatibility(): bool {
-		if ( version_compare( PHP_VERSION, self::MINIMUM_PHP_VERSION, '<' ) ) {
-			return false;
-		}
-
-		global $wp_version;
-		if ( version_compare( $wp_version, self::MINIMUM_WP_VERSION, '<' ) ) {
-			return false;
-		}
-
-		return true;
-	}
-
-	/**
-	 * Displays an admin notice regarding compatibility issues.
-	 *
-	 * This method outputs a notice in the WordPress admin area to inform users about
-	 * compatibility concerns related to the plugin or its environment.
-	 *
-	 * @return void
-	 */
-	public function admin_notice_compatibility(): void {
-		echo '<div class="notice notice-error"><p>';
-		if ( version_compare( PHP_VERSION, self::MINIMUM_PHP_VERSION, '<' ) ) {
-			echo esc_html__( 'Starmus Audio Recorder requires PHP version ' . self::MINIMUM_PHP_VERSION . ' or higher.', 'starmus-audio-recorder' ) . '<br>';
-		}
-		if ( version_compare( $GLOBALS['wp_version'], self::MINIMUM_WP_VERSION, '<' ) ) {
-			echo esc_html__( 'Starmus Audio Recorder requires WordPress version ' . self::MINIMUM_WP_VERSION . ' or higher.', 'starmus-audio-recorder' );
-		}
-		echo '</p></div>';
-	}
-
-	private function load_dependencies(): void {
-		require_once $this->plugin_path . 'includes/starmus-audio-recorder-handler.php';
-	}
-	
-	/**
-	 * Executes the main functionality of the Starmus Audio Recorder plugin.
-	 *
-	 * This static method is the entry point for running the plugin's core logic.
-	 * It should be called to initialize and start the audio recording features.
-	 *
-	 * @return void
-	 */
-	public static function starmus_run(): void {
-		if (
-			! isset( $GLOBALS['Starmus\AudioRecorder'] ) ||
-			! $GLOBALS['Starmus\AudioRecorder'] instanceof self
-		) {
-			$GLOBALS['Starmus\AudioRecorder'] = self::get_instance();
-		}
-	}
-
-	public static function starmus_activate(): void {
-		flush_rewrite_rules();
-	}
-
-	public static function starmus_deactivate(): void {
-		flush_rewrite_rules();
-	}
-
-	public static function starmus_uninstall(): void {
-		// Optional cleanup logic for uninstall.
-		// Example: delete_option('starmus_audio_recorder_settings');
-	}
-}
-
-register_activation_hook( __FILE__, array( 'Starmus\AudioRecorder', 'starmus_activate' ) );
-register_deactivation_hook( __FILE__, array( 'Starmus\AudioRecorder', 'starmus_deactivate' ) );
-register_uninstall_hook( __FILE__, array( 'Starmus\AudioRecorder', 'starmus_uninstall' ) );
-// Initialize the plugin
-add_action( 'plugins_loaded', array( 'Starmus\AudioRecorder', 'starmus_run' ) );
-
-
+add_action( 'plugins_loaded', [ 'Starisian\\src\\Core\\AudioRecorder', 'starmus_run' ] );


### PR DESCRIPTION
## Summary
- migrate plugin to PSR-4 structure under `src/`
- introduce lightweight autoloader and register in plugin bootstrap
- refactor AudioRecorder and submission handler into namespaced classes

## Testing
- `php -l starmus-audio-recorder.php src/includes/Autoloader.php src/Core/AudioRecorder.php src/Includes/StarmusAudioSubmissionHandler.php`


------
https://chatgpt.com/codex/tasks/task_e_689bbecb14f483328373875528bb4432