### PR TITLE
Add internationalization and JavaScript localization

### DIFF
--- a/includes/starmus-audio-recorder-handler.php
+++ b/includes/starmus-audio-recorder-handler.php
@@ -84,7 +84,7 @@ if (!class_exists('Starmus_Audio_Submission_Handler')) {
         {
             // Check if the request is an AJAX request
             if (!wp_doing_ajax()) {
-                wp_send_json_error(['success' => false, 'message' => 'Invalid request.'], 400);
+                wp_send_json_error(['success' => false, 'message' => __( 'Invalid request.', 'starmus-audio-recorder' )], 400);
                 return;
             }
             error_log('--- START SUBMISSION HANDLER ---');
@@ -97,18 +97,18 @@ if (!class_exists('Starmus_Audio_Submission_Handler')) {
             // }
 
             if (!isset($_POST[self::NONCE_FIELD]) || !wp_verify_nonce(sanitize_text_field(wp_unslash($_POST[self::NONCE_FIELD])), self::NONCE_ACTION)) {
-                wp_send_json_error(['success' => false, 'message' => 'Nonce verification failed.'], 403);
+                wp_send_json_error(['success' => false, 'message' => __( 'Nonce verification failed.', 'starmus-audio-recorder' )], 403);
                 return;
             }
 
             if (empty($_POST['audio_consent']) || sanitize_text_field($_POST['audio_consent']) !== 'on') {
-                wp_send_json_error(['success' => false, 'message' => 'Consent is required.'], 400);
+                wp_send_json_error(['success' => false, 'message' => __( 'Consent is required.', 'starmus-audio-recorder' )], 400);
                 return;
             }
 
             $uuid = isset($_POST['audio_uuid']) ? sanitize_text_field($_POST['audio_uuid']) : '';
             if (!$this->is_valid_uuid($uuid)) {
-                wp_send_json_error(['success' => false, 'message' => 'Invalid or missing UUID.'], 400);
+                wp_send_json_error(['success' => false, 'message' => __( 'Invalid or missing UUID.', 'starmus-audio-recorder' )], 400);
                 return;
             }
 
@@ -122,17 +122,17 @@ if (!class_exists('Starmus_Audio_Submission_Handler')) {
             $check = wp_check_filetype_and_ext($file['tmp_name'], $file['name']);
             error_log('DEBUG: wp_check_filetype_and_ext: ' . print_r($check, true));
             if (!$this->is_allowed_file_type($file['type'])) {
-                wp_send_json_error(['success' => false, 'message' => 'Unsupported audio file type: ' . esc_html($file['type'])], 400);
+                wp_send_json_error(['success' => false, 'message' => sprintf( __( 'Unsupported audio file type: %s', 'starmus-audio-recorder' ), esc_html($file['type']) )], 400);
                 return;
             }
             if (!$check['ext'] || !$check['type']) {
-                wp_send_json_error(['success' => false, 'message' => 'File type or extension not allowed (server check).'], 400);
+                wp_send_json_error(['success' => false, 'message' => __( 'File type or extension not allowed (server check).', 'starmus-audio-recorder' )], 400);
                 return;
             }
 
             $attachment_id = $this->upload_file_to_media_library('audio_file');
             if (is_wp_error($attachment_id)) {
-                wp_send_json_error(['success' => false, 'message' => 'Failed to save audio file: ' . $attachment_id->get_error_message()], 500);
+                wp_send_json_error(['success' => false, 'message' => sprintf( __( 'Failed to save audio file: %s', 'starmus-audio-recorder' ), $attachment_id->get_error_message() )], 500);
                 return;
             }
             
@@ -172,7 +172,7 @@ if (!class_exists('Starmus_Audio_Submission_Handler')) {
             $file = $_FILES['audio_file']; // Already validated
 
             $post_data = [
-                'post_title'   => 'Audio Recording ' . $audio_uuid_from_js,
+                'post_title'   => sprintf( __( 'Audio Recording %s', 'starmus-audio-recorder' ), $audio_uuid_from_js ),
                 'post_type'    => $this->get_target_post_type(),
                 'post_status'  => 'publish',
                 'post_author'  => $current_user_id, // Assign post to the logged-in user
@@ -201,7 +201,7 @@ if (!class_exists('Starmus_Audio_Submission_Handler')) {
 
             if (is_wp_error($post_id)) {
                 wp_delete_attachment($attachment_id, true);
-                wp_send_json_error(['success' => false, 'message' => 'Failed to create post: ' . $post_id->get_error_message()], 500);
+                wp_send_json_error(['success' => false, 'message' => sprintf( __( 'Failed to create post: %s', 'starmus-audio-recorder' ), $post_id->get_error_message() )], 500);
                 return;
             }
             update_post_meta($post_id, 'audio_file_type', $file['type']);
@@ -211,7 +211,7 @@ if (!class_exists('Starmus_Audio_Submission_Handler')) {
 
             wp_send_json_success([
                 'success' => true,
-                'message' => 'Submission successful.',
+                'message' => __( 'Submission successful.', 'starmus-audio-recorder' ),
                 'attachment_id' => $attachment_id,
                 'post_id' => $post_id,
             ], 200);
@@ -225,7 +225,7 @@ if (!class_exists('Starmus_Audio_Submission_Handler')) {
         {
             $attributes = shortcode_atts([
                 'form_id' => 'sparxstarAudioForm',
-                'submit_button_text' => 'Submit Recording',
+                'submit_button_text' => esc_html__( 'Submit Recording', 'starmus-audio-recorder' ),
             ], $atts);
 
             ob_start();
@@ -239,7 +239,7 @@ if (!class_exists('Starmus_Audio_Submission_Handler')) {
             if (file_exists($template_path)) {
                 include $template_path;
             } else {
-                echo '<p>Error: Audio recorder form template not found.</p>';
+                echo '<p>' . esc_html__( 'Error: Audio recorder form template not found.', 'starmus-audio-recorder' ) . '</p>';
             }
 
             return ob_get_clean();
@@ -260,6 +260,30 @@ if (!class_exists('Starmus_Audio_Submission_Handler')) {
                     true
                 );
 
+                wp_localize_script(
+                    'starmus-audio-recorder-module',
+                    'starmusRecorderStrings',
+                    [
+                        'network_lost'               => esc_html__( 'Network connection lost. Current recording is paused. Do NOT close page if you wish to save. Try to Stop and Submit when online.', 'starmus-audio-recorder' ),
+                        'network_restored_recording' => esc_html__( 'Network connection restored. You can now Stop your recording and Submit, or Delete and start over.', 'starmus-audio-recorder' ),
+                        'network_restored'           => esc_html__( 'Network connection restored.', 'starmus-audio-recorder' ),
+                        'ready_to_record'            => esc_html__( 'Ready to record.', 'starmus-audio-recorder' ),
+                        'recording_stopped'          => esc_html__( 'Recording stopped, no audio captured.', 'starmus-audio-recorder' ),
+                        'recording_complete'         => esc_html__( 'Recording complete. Play, Download, Delete, or Submit.', 'starmus-audio-recorder' ),
+                        'recording_saved_no_input'   => esc_html__( 'Recording saved locally. File input not found in form.', 'starmus-audio-recorder' ),
+                        'recording_saved_attached'   => esc_html__( 'Recording saved and attached to form.', 'starmus-audio-recorder' ),
+                        'recording_saved_no_support' => esc_html__( 'Recording saved, but your browser does not support automatic file attachment. Please try a different browser.', 'starmus-audio-recorder' ),
+                        'recording_saved_error'      => esc_html__( 'Recording saved locally. Error attaching to form.', 'starmus-audio-recorder' ),
+                        'mic_denied'                 => esc_html__( 'Microphone permission denied. Please allow mic access.', 'starmus-audio-recorder' ),
+                        'mic_failed'                 => esc_html__( 'Microphone permission check failed. Please check your browser settings.', 'starmus-audio-recorder' ),
+                        'level_unavailable'          => esc_html__( 'Audio level visualization not available.', 'starmus-audio-recorder' ),
+                        'recording_paused'           => esc_html__( 'Recording paused', 'starmus-audio-recorder' ),
+                        'recording_resumed'          => esc_html__( 'Recording resumed...', 'starmus-audio-recorder' ),
+                        'recorder_reset'             => esc_html__( 'Recorder reset.', 'starmus-audio-recorder' ),
+                        'unsupported_format'         => esc_html__( 'Unsupported recording format. Try a different browser.', 'starmus-audio-recorder' ),
+                    ]
+                );
+
                 wp_enqueue_script(
                     'starmus-audio-recorder-submissions',
                     $this->plugin_url . 'assets/js/starmus-audio-recorder-submissions.js',
@@ -268,11 +292,33 @@ if (!class_exists('Starmus_Audio_Submission_Handler')) {
                     true
                 );
 
-                wp_localize_script('starmus-audio-recorder-submissions', 'starmusFormData', [
-                    'ajax_url' => admin_url('admin-ajax.php'),
-                    'nonce_action' => self::NONCE_ACTION,
-                    'nonce_field' => self::NONCE_FIELD,
-                ]);
+                wp_localize_script(
+                    'starmus-audio-recorder-submissions',
+                    'starmusFormData',
+                    [
+                        'ajax_url'     => admin_url('admin-ajax.php'),
+                        'nonce_action' => self::NONCE_ACTION,
+                        'nonce_field'  => self::NONCE_FIELD,
+                        'strings'      => [
+                            'no_forms'             => esc_html__( 'No audio recorder forms found on this page.', 'starmus-audio-recorder' ),
+                            'recorder_failed'      => esc_html__( 'Recorder failed to load.', 'starmus-audio-recorder' ),
+                            'error_loading'        => esc_html__( 'Error loading recorder.', 'starmus-audio-recorder' ),
+                            'recorder_unavailable' => esc_html__( 'Critical error: Recorder unavailable.', 'starmus-audio-recorder' ),
+                            'recording_ready'      => esc_html__( 'Recording ready.', 'starmus-audio-recorder' ),
+                            'long_recording'       => esc_html__( 'Your recording is about %s min long and may take some time to upload.', 'starmus-audio-recorder' ),
+                            'submit_when_ready'    => esc_html__( 'Please submit when ready.', 'starmus-audio-recorder' ),
+                            'error_audio_missing'  => esc_html__( 'Error: Audio not recorded or Audio ID missing.', 'starmus-audio-recorder' ),
+                            'error_no_audio'       => esc_html__( 'Error: No audio file data to submit.', 'starmus-audio-recorder' ),
+                            'error_consent'        => esc_html__( 'Error: Consent is required.', 'starmus-audio-recorder' ),
+                            'submitting'           => esc_html__( 'Submitting your recording…', 'starmus-audio-recorder' ),
+                            'error_invalid'        => esc_html__( 'Error: Invalid server response. (%s)', 'starmus-audio-recorder' ),
+                            'submit_success'       => esc_html__( 'Successfully submitted!', 'starmus-audio-recorder' ),
+                            'error_unknown'        => esc_html__( 'Unknown server error.', 'starmus-audio-recorder' ),
+                            'error_template'       => esc_html__( 'Error: %s', 'starmus-audio-recorder' ),
+                            'network_error'        => esc_html__( 'Network error. Please check connection and try again.', 'starmus-audio-recorder' ),
+                        ],
+                    ]
+                );
 
                 wp_enqueue_style(
                     'starmus-audio-recorder-style',
@@ -383,43 +429,43 @@ if (!class_exists('Starmus_Audio_Submission_Handler')) {
             error_log('UPLOAD ERROR CODE: ' . $error_code);
             switch ($error_code) {
                 case UPLOAD_ERR_INI_SIZE:
-                    return "The uploaded file exceeds the upload_max_filesize directive in php.ini.";
+                    return __( 'The uploaded file exceeds the upload_max_filesize directive in php.ini.', 'starmus-audio-recorder' );
                 case UPLOAD_ERR_FORM_SIZE:
-                    return "The uploaded file exceeds the MAX_FILE_SIZE directive that was specified in the HTML form.";
+                    return __( 'The uploaded file exceeds the MAX_FILE_SIZE directive that was specified in the HTML form.', 'starmus-audio-recorder' );
                 case UPLOAD_ERR_PARTIAL:
-                    return "The uploaded file was only partially uploaded.";
+                    return __( 'The uploaded file was only partially uploaded.', 'starmus-audio-recorder' );
                 case UPLOAD_ERR_NO_FILE:
-                    return "No file was uploaded.";
+                    return __( 'No file was uploaded.', 'starmus-audio-recorder' );
                 case UPLOAD_ERR_NO_TMP_DIR:
-                    return "Missing a temporary folder.";
+                    return __( 'Missing a temporary folder.', 'starmus-audio-recorder' );
                 case UPLOAD_ERR_CANT_WRITE:
-                    return "Failed to write file to disk.";
+                    return __( 'Failed to write file to disk.', 'starmus-audio-recorder' );
                 case UPLOAD_ERR_EXTENSION:
-                    return "A PHP extension stopped the file upload.";
+                    return __( 'A PHP extension stopped the file upload.', 'starmus-audio-recorder' );
                 case UPLOAD_ERR_OK:
-                    return "File uploaded successfully.";
+                    return __( 'File uploaded successfully.', 'starmus-audio-recorder' );
                 case UPLOAD_ERR_EMPTY_FILE:
-                    return "The uploaded file is empty.";
+                    return __( 'The uploaded file is empty.', 'starmus-audio-recorder' );
                 case UPLOAD_ERR_INVALID_FILE:
-                    return "The uploaded file is invalid.";
+                    return __( 'The uploaded file is invalid.', 'starmus-audio-recorder' );
                 case UPLOAD_ERR_INVALID_TYPE:
-                    return "The uploaded file type is not allowed.";
+                    return __( 'The uploaded file type is not allowed.', 'starmus-audio-recorder' );
                 case UPLOAD_ERR_FILE_TOO_LARGE:
-                    return "The uploaded file is too large.";
+                    return __( 'The uploaded file is too large.', 'starmus-audio-recorder' );
                 case UPLOAD_ERR_FILE_NOT_FOUND:
-                    return "The uploaded file was not found.";
+                    return __( 'The uploaded file was not found.', 'starmus-audio-recorder' );
                 case UPLOAD_ERR_FILE_NOT_READABLE:
-                    return "The uploaded file is not readable.";
+                    return __( 'The uploaded file is not readable.', 'starmus-audio-recorder' );
                 case UPLOAD_ERR_FILE_NOT_WRITABLE:
-                    return "The uploaded file is not writable.";
+                    return __( 'The uploaded file is not writable.', 'starmus-audio-recorder' );
                 case UPLOAD_ERR_FILE_EXISTS:
-                    return "The uploaded file already exists.";
+                    return __( 'The uploaded file already exists.', 'starmus-audio-recorder' );
                 case UPLOAD_ERR_FILE_NOT_SUPPORTED:
-                    return "The uploaded file type is not supported.";
+                    return __( 'The uploaded file type is not supported.', 'starmus-audio-recorder' );
                 case UPLOAD_ERR_FILE_TOO_SHORT:
-                    return "The uploaded file is too short.";
+                    return __( 'The uploaded file is too short.', 'starmus-audio-recorder' );
                 default:
-                    return "Unknown upload error.";
+                    return __( 'Unknown upload error.', 'starmus-audio-recorder' );
             }
         }
     }

--- a/languages/starmus-audio-recorder.pot
+++ b/languages/starmus-audio-recorder.pot
@@ -1,0 +1,355 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-08-12 22:31+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: templates/starmus-audio-recorder-ui.php:26
+msgid "Audio Recorder"
+msgstr ""
+
+#: templates/starmus-audio-recorder-ui.php:31
+msgid "I give permission to record and submit my audio."
+msgstr ""
+
+#: templates/starmus-audio-recorder-ui.php:41
+#: includes/starmus-audio-recorder-handler.php:270
+msgid "Ready to record."
+msgstr ""
+
+#: templates/starmus-audio-recorder-ui.php:45
+msgid "Recording controls"
+msgstr ""
+
+#: templates/starmus-audio-recorder-ui.php:47
+msgid "Record"
+msgstr ""
+
+#: templates/starmus-audio-recorder-ui.php:49
+msgid "Pause"
+msgstr ""
+
+#: templates/starmus-audio-recorder-ui.php:51
+msgid "Delete"
+msgstr ""
+
+#: templates/starmus-audio-recorder-ui.php:59
+msgid "Microphone Level:"
+msgstr ""
+
+#: templates/starmus-audio-recorder-ui.php:76
+msgid "Recording Timer"
+msgstr ""
+
+#: templates/starmus-audio-recorder-ui.php:84
+msgid "Recorded audio preview"
+msgstr ""
+
+#: templates/starmus-audio-recorder-ui.php:89
+msgid "Download recorded audio"
+msgstr ""
+
+#: templates/starmus-audio-recorder-ui.php:91
+msgid "Download"
+msgstr ""
+
+#: templates/starmus-audio-recorder-ui.php:115
+msgid "Submitting… please wait."
+msgstr ""
+
+#: templates/starmus-audio-recorder-ui.php:123
+#: includes/starmus-audio-recorder-handler.php:313
+msgid "Submitting your recording…"
+msgstr ""
+
+#: templates/starmus-audio-recorder-ui.php:124
+msgid ""
+"Large recordings may take several minutes to upload. Please keep this window "
+"open."
+msgstr ""
+
+#: starmus-audio-recorder.php:127
+#, php-format
+msgid "Starmus Audio Recorder requires PHP version %s or higher."
+msgstr ""
+
+#: starmus-audio-recorder.php:131
+#, php-format
+msgid "Starmus Audio Recorder requires WordPress version %s or higher."
+msgstr ""
+
+#: includes/starmus-audio-recorder-handler.php:87
+msgid "Invalid request."
+msgstr ""
+
+#: includes/starmus-audio-recorder-handler.php:100
+msgid "Nonce verification failed."
+msgstr ""
+
+#: includes/starmus-audio-recorder-handler.php:105
+msgid "Consent is required."
+msgstr ""
+
+#: includes/starmus-audio-recorder-handler.php:111
+msgid "Invalid or missing UUID."
+msgstr ""
+
+#: includes/starmus-audio-recorder-handler.php:125
+#, php-format
+msgid "Unsupported audio file type: %s"
+msgstr ""
+
+#: includes/starmus-audio-recorder-handler.php:129
+msgid "File type or extension not allowed (server check)."
+msgstr ""
+
+#: includes/starmus-audio-recorder-handler.php:135
+#, php-format
+msgid "Failed to save audio file: %s"
+msgstr ""
+
+#: includes/starmus-audio-recorder-handler.php:175
+#, php-format
+msgid "Audio Recording %s"
+msgstr ""
+
+#: includes/starmus-audio-recorder-handler.php:204
+#, php-format
+msgid "Failed to create post: %s"
+msgstr ""
+
+#: includes/starmus-audio-recorder-handler.php:214
+msgid "Submission successful."
+msgstr ""
+
+#: includes/starmus-audio-recorder-handler.php:228
+msgid "Submit Recording"
+msgstr ""
+
+#: includes/starmus-audio-recorder-handler.php:242
+msgid "Error: Audio recorder form template not found."
+msgstr ""
+
+#: includes/starmus-audio-recorder-handler.php:267
+msgid ""
+"Network connection lost. Current recording is paused. Do NOT close page if "
+"you wish to save. Try to Stop and Submit when online."
+msgstr ""
+
+#: includes/starmus-audio-recorder-handler.php:268
+msgid ""
+"Network connection restored. You can now Stop your recording and Submit, or "
+"Delete and start over."
+msgstr ""
+
+#: includes/starmus-audio-recorder-handler.php:269
+msgid "Network connection restored."
+msgstr ""
+
+#: includes/starmus-audio-recorder-handler.php:271
+msgid "Recording stopped, no audio captured."
+msgstr ""
+
+#: includes/starmus-audio-recorder-handler.php:272
+msgid "Recording complete. Play, Download, Delete, or Submit."
+msgstr ""
+
+#: includes/starmus-audio-recorder-handler.php:273
+msgid "Recording saved locally. File input not found in form."
+msgstr ""
+
+#: includes/starmus-audio-recorder-handler.php:274
+msgid "Recording saved and attached to form."
+msgstr ""
+
+#: includes/starmus-audio-recorder-handler.php:275
+msgid ""
+"Recording saved, but your browser does not support automatic file "
+"attachment. Please try a different browser."
+msgstr ""
+
+#: includes/starmus-audio-recorder-handler.php:276
+msgid "Recording saved locally. Error attaching to form."
+msgstr ""
+
+#: includes/starmus-audio-recorder-handler.php:277
+msgid "Microphone permission denied. Please allow mic access."
+msgstr ""
+
+#: includes/starmus-audio-recorder-handler.php:278
+msgid "Microphone permission check failed. Please check your browser settings."
+msgstr ""
+
+#: includes/starmus-audio-recorder-handler.php:279
+msgid "Audio level visualization not available."
+msgstr ""
+
+#: includes/starmus-audio-recorder-handler.php:280
+msgid "Recording paused"
+msgstr ""
+
+#: includes/starmus-audio-recorder-handler.php:281
+msgid "Recording resumed..."
+msgstr ""
+
+#: includes/starmus-audio-recorder-handler.php:282
+msgid "Recorder reset."
+msgstr ""
+
+#: includes/starmus-audio-recorder-handler.php:283
+msgid "Unsupported recording format. Try a different browser."
+msgstr ""
+
+#: includes/starmus-audio-recorder-handler.php:303
+msgid "No audio recorder forms found on this page."
+msgstr ""
+
+#: includes/starmus-audio-recorder-handler.php:304
+msgid "Recorder failed to load."
+msgstr ""
+
+#: includes/starmus-audio-recorder-handler.php:305
+msgid "Error loading recorder."
+msgstr ""
+
+#: includes/starmus-audio-recorder-handler.php:306
+msgid "Critical error: Recorder unavailable."
+msgstr ""
+
+#: includes/starmus-audio-recorder-handler.php:307
+msgid "Recording ready."
+msgstr ""
+
+#: includes/starmus-audio-recorder-handler.php:308
+#, php-format
+msgid "Your recording is about %s min long and may take some time to upload."
+msgstr ""
+
+#: includes/starmus-audio-recorder-handler.php:309
+msgid "Please submit when ready."
+msgstr ""
+
+#: includes/starmus-audio-recorder-handler.php:310
+msgid "Error: Audio not recorded or Audio ID missing."
+msgstr ""
+
+#: includes/starmus-audio-recorder-handler.php:311
+msgid "Error: No audio file data to submit."
+msgstr ""
+
+#: includes/starmus-audio-recorder-handler.php:312
+msgid "Error: Consent is required."
+msgstr ""
+
+#: includes/starmus-audio-recorder-handler.php:314
+#, php-format
+msgid "Error: Invalid server response. (%s)"
+msgstr ""
+
+#: includes/starmus-audio-recorder-handler.php:315
+msgid "Successfully submitted!"
+msgstr ""
+
+#: includes/starmus-audio-recorder-handler.php:316
+msgid "Unknown server error."
+msgstr ""
+
+#: includes/starmus-audio-recorder-handler.php:317
+#, php-format
+msgid "Error: %s"
+msgstr ""
+
+#: includes/starmus-audio-recorder-handler.php:318
+msgid "Network error. Please check connection and try again."
+msgstr ""
+
+#: includes/starmus-audio-recorder-handler.php:432
+msgid "The uploaded file exceeds the upload_max_filesize directive in php.ini."
+msgstr ""
+
+#: includes/starmus-audio-recorder-handler.php:434
+msgid ""
+"The uploaded file exceeds the MAX_FILE_SIZE directive that was specified in "
+"the HTML form."
+msgstr ""
+
+#: includes/starmus-audio-recorder-handler.php:436
+msgid "The uploaded file was only partially uploaded."
+msgstr ""
+
+#: includes/starmus-audio-recorder-handler.php:438
+msgid "No file was uploaded."
+msgstr ""
+
+#: includes/starmus-audio-recorder-handler.php:440
+msgid "Missing a temporary folder."
+msgstr ""
+
+#: includes/starmus-audio-recorder-handler.php:442
+msgid "Failed to write file to disk."
+msgstr ""
+
+#: includes/starmus-audio-recorder-handler.php:444
+msgid "A PHP extension stopped the file upload."
+msgstr ""
+
+#: includes/starmus-audio-recorder-handler.php:446
+msgid "File uploaded successfully."
+msgstr ""
+
+#: includes/starmus-audio-recorder-handler.php:448
+msgid "The uploaded file is empty."
+msgstr ""
+
+#: includes/starmus-audio-recorder-handler.php:450
+msgid "The uploaded file is invalid."
+msgstr ""
+
+#: includes/starmus-audio-recorder-handler.php:452
+msgid "The uploaded file type is not allowed."
+msgstr ""
+
+#: includes/starmus-audio-recorder-handler.php:454
+msgid "The uploaded file is too large."
+msgstr ""
+
+#: includes/starmus-audio-recorder-handler.php:456
+msgid "The uploaded file was not found."
+msgstr ""
+
+#: includes/starmus-audio-recorder-handler.php:458
+msgid "The uploaded file is not readable."
+msgstr ""
+
+#: includes/starmus-audio-recorder-handler.php:460
+msgid "The uploaded file is not writable."
+msgstr ""
+
+#: includes/starmus-audio-recorder-handler.php:462
+msgid "The uploaded file already exists."
+msgstr ""
+
+#: includes/starmus-audio-recorder-handler.php:464
+msgid "The uploaded file type is not supported."
+msgstr ""
+
+#: includes/starmus-audio-recorder-handler.php:466
+msgid "The uploaded file is too short."
+msgstr ""
+
+#: includes/starmus-audio-recorder-handler.php:468
+msgid "Unknown upload error."
+msgstr ""

--- a/starmus-audio-recorder.php
+++ b/starmus-audio-recorder.php
@@ -123,12 +123,13 @@ final class AudioRecorder {
 	 */
 	public function admin_notice_compatibility(): void {
 		echo '<div class="notice notice-error"><p>';
-		if ( version_compare( PHP_VERSION, self::MINIMUM_PHP_VERSION, '<' ) ) {
-			echo esc_html__( 'Starmus Audio Recorder requires PHP version ' . self::MINIMUM_PHP_VERSION . ' or higher.', 'starmus-audio-recorder' ) . '<br>';
-		}
-		if ( version_compare( $GLOBALS['wp_version'], self::MINIMUM_WP_VERSION, '<' ) ) {
-			echo esc_html__( 'Starmus Audio Recorder requires WordPress version ' . self::MINIMUM_WP_VERSION . ' or higher.', 'starmus-audio-recorder' );
-		}
+                if ( version_compare( PHP_VERSION, self::MINIMUM_PHP_VERSION, '<' ) ) {
+                        printf( esc_html__( 'Starmus Audio Recorder requires PHP version %s or higher.', 'starmus-audio-recorder' ), self::MINIMUM_PHP_VERSION );
+                        echo '<br>';
+                }
+                if ( version_compare( $GLOBALS['wp_version'], self::MINIMUM_WP_VERSION, '<' ) ) {
+                        printf( esc_html__( 'Starmus Audio Recorder requires WordPress version %s or higher.', 'starmus-audio-recorder' ), self::MINIMUM_WP_VERSION );
+                }
 		echo '</p></div>';
 	}
 
@@ -172,5 +173,10 @@ register_deactivation_hook( __FILE__, array( 'Starmus\AudioRecorder', 'starmus_d
 register_uninstall_hook( __FILE__, array( 'Starmus\AudioRecorder', 'starmus_uninstall' ) );
 // Initialize the plugin
 add_action( 'plugins_loaded', array( 'Starmus\AudioRecorder', 'starmus_run' ) );
+
+function starmus_load_textdomain(): void {
+        \load_plugin_textdomain( 'starmus-audio-recorder', false, dirname( \plugin_basename( __FILE__ ) ) . '/languages' );
+}
+add_action( 'plugins_loaded', __NAMESPACE__ . '\\starmus_load_textdomain', 0 );
 
 

--- a/templates/starmus-audio-recorder-ui.php
+++ b/templates/starmus-audio-recorder-ui.php
@@ -23,12 +23,12 @@ if (!isset($unique_suffix)) {
 
   <!--audioWrapper-->
   <div id="starmus_audioWrapper_<?php echo esc_attr($form_id); ?>" class="sparxstar-audioWrapper" data-enabled-recorder>
-    <h2 id="sparxstar_audioRecorderHeading_<?php echo esc_attr($form_id); ?>" class="sparxstar-h2">Audio Recorder</h2>
+    <h2 id="sparxstar_audioRecorderHeading_<?php echo esc_attr($form_id); ?>" class="sparxstar-h2"><?php echo esc_html__( 'Audio Recorder', 'starmus-audio-recorder' ); ?></h2>
 
     <!-- Consent Checkbox -->
     <label for="audio_consent_<?php echo esc_attr($form_id); ?>" ...>
       <input type="checkbox" id="audio_consent_<?php echo esc_attr($form_id); ?>" name="audio_consent" required>
-      I give permission to record and submit my audio.
+      <?php echo esc_html__( 'I give permission to record and submit my audio.', 'starmus-audio-recorder' ); ?>
     </label>
 
     <!-- Recorder -->
@@ -38,17 +38,17 @@ if (!isset($unique_suffix)) {
       <!-- Status Message -->
       <div id="sparxstar_status_<?php echo esc_attr($form_id); ?>" role="status" aria-live="polite"
         class="sparxstar_visually_hidden">
-        <span class="sparxstar_status__text">Ready to record.</span>
+        <span class="sparxstar_status__text"><?php echo esc_html__( 'Ready to record.', 'starmus-audio-recorder' ); ?></span>
       </div>
 
       <!-- Recorder Controls -->
-      <div class="sparxstar_recorderControls" role="group" aria-label="Recording controls">
+      <div class="sparxstar_recorderControls" role="group" aria-label="<?php echo esc_attr__( 'Recording controls', 'starmus-audio-recorder' ); ?>">
         <button type="button" id="recordButton_<?php echo esc_attr($form_id); ?>"
-          class="sparxstar_button">Record</button>
+          class="sparxstar_button"><?php echo esc_html__( 'Record', 'starmus-audio-recorder' ); ?></button>
         <button type="button" id="pauseButton_<?php echo esc_attr($form_id); ?>" class="sparxstar_button"
-          disabled>Pause</button>
+          disabled><?php echo esc_html__( 'Pause', 'starmus-audio-recorder' ); ?></button>
         <button type="button" id="deleteButton_<?php echo esc_attr($form_id); ?>"
-          class="sparxstar_button sparxstar_button--danger sparxstar_visually_hidden" disabled>Delete</button>
+          class="sparxstar_button sparxstar_button--danger sparxstar_visually_hidden" disabled><?php echo esc_html__( 'Delete', 'starmus-audio-recorder' ); ?></button>
 
       </div>
 
@@ -56,7 +56,7 @@ if (!isset($unique_suffix)) {
       <div id="sparxstar_audioLevelContainer_<?php echo esc_attr($form_id); ?>" class="sparxstar_audioLevelContainer">
         <label id="sparxstar_audioLevelVisibleLabel_<?php echo esc_attr($form_id); ?>"
           for="sparxstar_audioLevelBar_<?php echo esc_attr($form_id); ?>" class="sparxstar_audioLevelVisibleLabel">
-          Microphone Level:
+          <?php echo esc_html__( 'Microphone Level:', 'starmus-audio-recorder' ); ?>
         </label>
         <div id="sparxstar_audioLevelWrap_<?php echo esc_attr($form_id); ?>" class="sparxstar_audioLevelWrap">
           <div id="sparxstar_audioLevelBar_<?php echo esc_attr($form_id); ?>" class="sparxstar_audioLevelBar"
@@ -73,8 +73,7 @@ if (!isset($unique_suffix)) {
       <!-- Timer Display -->
       <div id="sparxstar_audioTimerContainer_<?php echo esc_attr($form_id); ?>" class="sparxstar_audioTimerContainer"
         aria-live="polite">
-        <label for="sparxstar_timer_<?php echo esc_attr($form_id); ?>" class="sparxstar_visually_hidden">Recording
-          Timer</label>
+        <label for="sparxstar_timer_<?php echo esc_attr($form_id); ?>" class="sparxstar_visually_hidden"><?php echo esc_html__( 'Recording Timer', 'starmus-audio-recorder' ); ?></label>
         <div id="sparxstar_timer_<?php echo esc_attr($form_id); ?>" class="sparxstar_timer" role="timer"
           aria-live="polite">00:00</div>
       </div>
@@ -82,14 +81,14 @@ if (!isset($unique_suffix)) {
 
       <!-- Audio Playback -->
       <audio id="sparxstar_audioPlayer_<?php echo esc_attr($form_id); ?>" class="sparxstar_audioPlayer" controls
-        aria-label="Recorded audio preview"></audio>
+        aria-label="<?php echo esc_attr__( 'Recorded audio preview', 'starmus-audio-recorder' ); ?>"></audio>
 
       <!-- Download Link -->
       <a id="sparxstar_audioDownload_<?php echo esc_attr($form_id); ?>"
         class="sparxstar_button sparxstar_audioDownload sparxstar_visually_hidden" href="#"
-        download="audio_recording.wav" aria-label="Download recorded audio" aria-disabled="true">
+        download="audio_recording.wav" aria-label="<?php echo esc_attr__( 'Download recorded audio', 'starmus-audio-recorder' ); ?>" aria-disabled="true">
         <!-- Use aria-disabled -->
-        Download
+        <?php echo esc_html__( 'Download', 'starmus-audio-recorder' ); ?>
       </a>
 
       <!-- Hidden Inputs for Form Submission -->
@@ -100,7 +99,7 @@ if (!isset($unique_suffix)) {
 
     <!-- Submit -->
     <button type="submit" id="submit_button_<?php echo esc_attr($form_id); ?>" class="sparxstar_submitButton"
-      disabled>Submit Recording</button>
+      disabled><?php echo esc_html( $submit_button_text ); ?></button>
 
     <!-- Hidden fields  -->
     <input type="hidden" name="submission_id" id="submission_id_<?php echo esc_attr($form_id); ?>" value="" />
@@ -113,7 +112,7 @@ if (!isset($unique_suffix)) {
     <!-- Submit Loader -->
     <div id="sparxstar_status_loader_<?php echo esc_attr($form_id); ?>" class="sparxstar_status sparxstar_visually_hidden"
       aria-live="polite">
-      <span class="sparxstar_status__text">Submitting… please wait.</span>
+      <span class="sparxstar_status__text"><?php echo esc_html__( 'Submitting… please wait.', 'starmus-audio-recorder' ); ?></span>
     </div>
 
     <!-- Submit Loader / Overlay -->
@@ -121,10 +120,8 @@ if (!isset($unique_suffix)) {
       class="sparxstar_loader_overlay sparxstar_visually_hidden" role="alert" aria-live="assertive">
       <div class="sparxstar_loader_content">
         <div class="sparxstar_spinner"></div>
-        <span id="sparxstar_loader_text_<?php echo esc_attr($form_id); ?>" class="sparxstar_status__text">Submitting
-          your recording…</span>
-        <p class="sparxstar_upload_eta_note">Large recordings may take several minutes to upload. Please keep this
-          window open.</p>
+        <span id="sparxstar_loader_text_<?php echo esc_attr($form_id); ?>" class="sparxstar_status__text"><?php echo esc_html__( 'Submitting your recording…', 'starmus-audio-recorder' ); ?></span>
+        <p class="sparxstar_upload_eta_note"><?php echo esc_html__( 'Large recordings may take several minutes to upload. Please keep this window open.', 'starmus-audio-recorder' ); ?></p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- load plugin text domain on `plugins_loaded`
- localize PHP template, handler messages, and frontend scripts
- provide translation template in `languages/`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689bbecda9048332aae9e1f690158990