### PR TITLE
Align handler class naming with namespace conventions

### DIFF
--- a/includes/StarmusAudioSubmissionHandler.php
+++ b/includes/StarmusAudioSubmissionHandler.php
@@ -6,7 +6,7 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
-if (!class_exists('Starmus_Audio_Submission_Handler')) {
+if ( ! class_exists( __NAMESPACE__ . '\StarmusAudioSubmissionHandler' ) ) {
 
     class StarmusAudioSubmissionHandler
     {

--- a/starmus-audio-recorder.php
+++ b/starmus-audio-recorder.php
@@ -45,7 +45,7 @@ if ( ! defined( 'STARMUS_VERSION' ) ) {
 }
 
 
-use Starmus\includes\StarmusAudioRecorderHandler;
+use Starmus\includes\StarmusAudioSubmissionHandler;
 
 /**
  * Class AudioRecorder
@@ -84,7 +84,7 @@ final class AudioRecorder {
 		$this->load_dependencies();
 		// add the handler
 		if ( ! isset( $this->StarmusHandler ) ) {
-			$this->StarmusHandler = new \Starmus\includes\StarmusAudioSubmissionHandler();
+			$this->StarmusHandler = new StarmusAudioSubmissionHandler();
 		}
 	}
 
@@ -133,7 +133,7 @@ final class AudioRecorder {
 	}
 
 	private function load_dependencies(): void {
-		require_once $this->plugin_path . 'includes/starmus-audio-recorder-handler.php';
+		require_once $this->plugin_path . 'includes/StarmusAudioSubmissionHandler.php';
 	}
 	
 	/**


### PR DESCRIPTION
## Summary
- ensure StarmusAudioSubmissionHandler uses namespaced class_exists check
- rename handler file and update bootstrap references

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689bbed12fe48332bd889576deea73ba