### PR TITLE
Expose StarmusPlugin singleton

### DIFF
--- a/src/includes/StarmusPlugin.php
+++ b/src/includes/StarmusPlugin.php
@@ -20,18 +20,15 @@ use Starisian\src\frontend\StarmusAudioRecorderUI;
 class StarmusPlugin {
     private static ?StarmusPlugin $instance = null;
 
-    public function __construct() {
+    private function __construct() {
         // Initialize the plugin's components.
-        // This is the single entry point for loading functionality.
-        $this->get_instance();
     }
 
-    private function get_instance(): StarmusPlugin {
-        static $instance = null;
-        if ( null === $instance ) {
-            $instance = new self();
+    public static function get_instance(): StarmusPlugin {
+        if ( null === self::$instance ) {
+            self::$instance = new self();
         }
-        return $instance;
+        return self::$instance;
     }
 
     public function init() {

--- a/starmus-audio-recorder.php
+++ b/starmus-audio-recorder.php
@@ -92,13 +92,13 @@ final class StarmusAudioRecorder {
 		return;
 	}
 
-	public function init(): void {
-		$this->get_starmus_plugin()->init();
-	}
+        public function init(): void {
+                StarmusPlugin::get_instance()->init();
+        }
 
-	public function get_starmus_plugin(): StarmusPlugin {
-		return $this->starmus_plugin;
-	}
+        public function get_starmus_plugin(): StarmusPlugin {
+                return $this->starmus_plugin;
+        }
 
 	/**
 	 * FIX: Activation callback. ONLY flush rewrite rules.


### PR DESCRIPTION
## Summary
- Make `StarmusPlugin::get_instance()` public static and simplify constructor
- Call `StarmusPlugin::get_instance()->init()` during plugin init

## Testing
- `npm test` *(fails: Missing script "test")*
- `composer lint:php` *(fails: vendor/bin/phpcs: not found)*
- `composer install` *(fails: CONNECT tunnel failed, response 403)*
- `composer test:php` *(fails: vendor/bin/phpunit: not found)*
- `composer analyze:php` *(fails: vendor/bin/phpstan: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab66f15a708332902d8966aa8c986f