### PR TITLE
fix: update plugin metadata and CPT path

### DIFF
--- a/starmus-audio-recorder.php
+++ b/starmus-audio-recorder.php
@@ -20,9 +20,9 @@ use Starisian\src\Autoloader;
  * Plugin Name:       Starmus Audio Recorder
  * Plugin URI:        https://github.com/Starisian-Technologies/starmus-audio-recorder
  * Description:       Adds a mobile-friendly MP3 audio recorder for oral history submission in low-bandwidth environments.
- * Version:           0.2.0
- * Requires at least: 5.2
- * Requires PHP:      7.2
+ * Version:           0.3.1
+ * Requires at least: 6.4
+ * Requires PHP:      8.2
  * Author:            Starisian Technologies (Max Barrett)
  * Author URI:        https://starisian.com
  * Text Domain:       starmus-audio-recorder
@@ -48,7 +48,7 @@ if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
 }
 
 // This file contains all add_action('init', ...) calls for CPTs and Taxonomies.
-require_once STARMUS_PATH . 'includes/StarmusCustomPostType.php';
+require_once STARMUS_PATH . 'src/includes/StarmusCustomPostType.php';
 
 
 use Starisian\src\includes\StarmusPlugin;


### PR DESCRIPTION
## Summary
- sync plugin header version with `STARMUS_VERSION`
- require `StarmusCustomPostType` from new `src/includes` location
- bump WordPress and PHP minimum versions

## Testing
- `php -l starmus-audio-recorder.php`
- `composer lint:php` *(fails: vendor/bin/phpcs: not found)*
- `composer install` *(fails: curl error 56, CONNECT tunnel failed 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ab66bbd7688332b87eefe2465b12f4