### PR TITLE
Add environment compatibility checks

### DIFF
--- a/starmus-audio-recorder.php
+++ b/starmus-audio-recorder.php
@@ -137,7 +137,37 @@ final class StarmusAudioRecorder {
 		}
 	}
     
-    // Paste your other methods (check_compatibility, display_compatibility_notice, clone, wakeup) here.
+    private function check_compatibility(): bool {
+        if ( version_compare( PHP_VERSION, self::MINIMUM_PHP_VERSION, '<' ) ) {
+            $this->compatibility_messages[] = sprintf(
+                __( 'Starmus Audio Recorder requires PHP %1$s or higher. You are running %2$s.', 'starmus-audio-recorder' ),
+                self::MINIMUM_PHP_VERSION,
+                PHP_VERSION
+            );
+        }
+
+        if ( version_compare( get_bloginfo( 'version' ), self::MINIMUM_WP_VERSION, '<' ) ) {
+            $this->compatibility_messages[] = sprintf(
+                __( 'Starmus Audio Recorder requires WordPress %1$s or higher. You are running %2$s.', 'starmus-audio-recorder' ),
+                self::MINIMUM_WP_VERSION,
+                get_bloginfo( 'version' )
+            );
+        }
+
+        return empty( $this->compatibility_messages );
+    }
+
+    public function display_compatibility_notice(): void {
+        foreach ( $this->compatibility_messages as $message ) {
+            echo '<div class="notice notice-error"><p>' . esc_html( $message ) . '</p></div>';
+        }
+    }
+
+    private function __clone() {}
+
+    public function __wakeup() {
+        $this->check_compatibility();
+    }
 }
 
 // Register plugin lifecycle hooks.


### PR DESCRIPTION
## Summary
- ensure PHP and WordPress version requirements are met before loading plugin
- surface admin notice when environment requirements are not satisfied

## Testing
- ⚠️ `composer install --no-interaction` *(failed: CONNECT tunnel failed, response 403)*
- ⚠️ `composer lint:php` *(failed: vendor/bin/phpcs not found)*
- ⚠️ `composer analyze:php` *(failed: vendor/bin/phpstan not found)*
- ⚠️ `composer test:php` *(failed: vendor/bin/phpunit not found)*
- ✅ `php -l starmus-audio-recorder.php`


------
https://chatgpt.com/codex/tasks/task_e_68ab66dc41a88332afc46ecfe0bcc88d