### PR TITLE
Bootstrap WordPress test environment

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,5 +1,26 @@
 <?php
-$autoload = __DIR__ . '/../../vendor/autoload.php';
-if (file_exists($autoload)) {
+$autoload = dirname(__DIR__) . '/vendor/autoload.php';
+if ( file_exists( $autoload ) ) {
     require $autoload;
 }
+
+$_tests_dir = getenv( 'WP_PHPUNIT__DIR' );
+if ( ! $_tests_dir ) {
+    $_tests_dir = dirname(__DIR__) . '/vendor/wp-phpunit/wp-phpunit';
+}
+
+if ( ! file_exists( $_tests_dir . '/includes/bootstrap.php' ) ) {
+    fwrite( STDERR, "Could not find WordPress tests in {$_tests_dir}.\n" );
+    exit( 1 );
+}
+
+require_once $_tests_dir . '/includes/functions.php';
+
+tests_add_filter(
+    'muplugins_loaded',
+    function () {
+        require dirname(__DIR__) . '/starmus-audio-recorder.php';
+    }
+);
+
+require $_tests_dir . '/includes/bootstrap.php';


### PR DESCRIPTION
## Summary
- set up WordPress test suite bootstrapper
- load plugin file during tests

## Testing
- `composer test:php` *(fails: vendor/bin/phpunit: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab676fba58833287d92aa7ef1e15d4