### PR TITLE
refactor: bootstrap plugin via main class

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,8 @@
   "license": "proprietary",
   "autoload": {
     "psr-4": {
-      "Starisian\\src\\": "src/"
+      "Starisian\\src\\": "src/",
+      "Starisian\\Starmus\\": "src/"
     }
   },
   "authors": [

--- a/src/Autoloader.php
+++ b/src/Autoloader.php
@@ -17,93 +17,63 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class Autoloader {
-	/**
-	 * Cached base directory path for performance optimization.
-	 *
-	 * @var string|null
-	 */
-	private static $realBaseDir = null;
+        /**
+         * Namespace prefixes and their base directories.
+         *
+         * @var array<string,string>
+         */
+        private static array $prefixes = [];
 
-	/**
-	 * Registers the autoload method with PHP's SPL autoloader stack.
-	 *
-	 * This is the entry point that tells PHP to use our `loadClass` method
-	 * whenever it encounters a class that hasn't been defined yet.
-	 *
-	 * @return void
-	 */
-	public static function register(): void {
-		// Initialize cached base directory
-		if ( null === self::$realBaseDir ) {
-			$baseDir = dirname( __DIR__ ) . '/';
-			self::$realBaseDir = realpath( $baseDir );
-		}
-		spl_autoload_register( [ self::class, 'loadClass' ] );
-	}
+        /**
+         * Registers the autoload method with PHP's SPL autoloader stack.
+         *
+         * @return void
+         */
+        public static function register(): void {
+                self::$prefixes = [
+                        'Starisian\\src\\'     => realpath( dirname( __DIR__ ) . '/src/' ),
+                        'Starisian\\Starmus\\' => realpath( dirname( __DIR__ ) . '/src/' ),
+                ];
+                spl_autoload_register( [ self::class, 'loadClass' ] );
+        }
 
-	/**
-	 * Loads a class file after performing security and path validation.
-	 *
-	 * @param string $class The fully-qualified class name (e.g., "Starisian\src\Includes\StarmusAudioSubmissionHandler").
-	 * @return void
-	 */
-	private static function loadClass( string $class ): void {
-		// 1. Define the namespace prefix this autoloader is responsible for.
-		$prefix = 'Starisian\\src\\';
+        /**
+         * Loads a class file after performing security and path validation.
+         *
+         * @param string $class Fully-qualified class name.
+         * @return void
+         */
+        private static function loadClass( string $class ): void {
+                foreach ( self::$prefixes as $prefix => $baseDir ) {
+                        if ( ! str_starts_with( $class, $prefix ) ) {
+                                continue;
+                        }
 
-		// 2. Interoperability Check:
-		// If the class does not start with our prefix, do nothing. This allows
-		// other autoloaders (from WordPress core, themes, or other plugins) to handle it.
-		// Uses str_starts_with() for improved readability (PHP 8.0+).
-		if ( ! str_starts_with( $class, $prefix ) ) {
-			return;
-		}
+                        if ( ! preg_match( '/^[a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff\\]*$/', $class ) ) {
+                                return;
+                        }
 
-		// 3. Additional input validation for class name
-		if ( ! preg_match( '/^[a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff\\]*$/', $class ) ) {
-			return;
-		}
+                        $relativeClass = substr( $class, strlen( $prefix ) );
+                        if ( strpos( $relativeClass, '..' ) !== false || strpos( $relativeClass, '/' ) === 0 ) {
+                                return;
+                        }
 
-		// 4. Convert the class name to a file path according to PSR-4 standard.
-		// - Remove the namespace prefix from the class name.
-		// - Replace namespace separators (\) with directory separators (/).
-		// - Append the .php extension.
-		$relativeClass = substr( $class, strlen( $prefix ) );
-		
-		// Additional validation on relative class path
-		if ( strpos( $relativeClass, '..' ) !== false || strpos( $relativeClass, '/' ) === 0 ) {
-			return;
-		}
-		
-		$baseDir = dirname( __DIR__ ) . '/';
-		$filePath = $baseDir . str_replace( '\\', '/', $relativeClass ) . '.php';
+                        $filePath = $baseDir . '/' . str_replace( '\\', '/', $relativeClass ) . '.php';
+                        $realPath = realpath( $filePath );
+                        if ( false === $realPath ) {
+                                return;
+                        }
 
-		// 5. Security - Path Canonicalization and Existence Check:
-		// `realpath()` resolves all symbolic links, '.', and '..' path segments.
-		// It returns the absolute, canonicalized path, or `false` if the file does not exist.
-		// This is a crucial first step in preventing path manipulation.
-		$realPath = realpath( $filePath );
-		if ( false === $realPath ) {
-			return;
-		}
+                        if ( ! str_starts_with( $realPath, $baseDir . DIRECTORY_SEPARATOR ) ) {
+                                return;
+                        }
 
-		// 6. Security - Directory Jailing:
-		// This is the most critical security check. We ensure that the resolved,
-		// absolute path of the file to be included is *within* our allowed base directory.
-		// This makes it impossible for the autoloader to be tricked into including a sensitive
-		// file from elsewhere on the server (e.g., ../../../wp-config.php).
-		if ( false === self::$realBaseDir || ! str_starts_with( $realPath, self::$realBaseDir . DIRECTORY_SEPARATOR ) ) {
-			return;
-		}
-		
-		// Additional security: ensure file has .php extension
-		if ( ! str_ends_with( $realPath, '.php' ) ) {
-			return;
-		}
+                        if ( ! str_ends_with( $realPath, '.php' ) ) {
+                                return;
+                        }
 
-		// 7. Include the File:
-		// All checks have passed; the file is confirmed to be a valid, existing file
-		// located safely within our plugin's directory.
-		require $realPath;
-	}
+                        require $realPath;
+                        return;
+                }
+        }
 }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * Main plugin loader.
+ *
+ * @package Starisian\Starmus
+ */
+
+namespace Starisian\Starmus;
+
+use Exception;
+use Starisian\src\includes\StarmusPlugin;
+
+final class Plugin {
+    public const MINIMUM_PHP_VERSION = '8.2';
+    public const MINIMUM_WP_VERSION = '6.4';
+
+    private StarmusPlugin $starmus_plugin;
+    private array $compatibility_messages = [];
+
+    public function __construct() {
+        if ( ! $this->check_compatibility() ) {
+            add_action( 'admin_notices', [ $this, 'display_compatibility_notice' ] );
+            return;
+        }
+
+        $this->load_starmus_plugin();
+
+        register_activation_hook( STARMUS_MAIN_FILE, [ self::class, 'activate' ] );
+        register_deactivation_hook( STARMUS_MAIN_FILE, [ self::class, 'deactivate' ] );
+        register_uninstall_hook( STARMUS_MAIN_FILE, [ self::class, 'uninstall' ] );
+
+        add_action( 'init', [ $this, 'init' ] );
+    }
+
+    private function load_starmus_plugin(): void {
+        try {
+            $this->starmus_plugin = StarmusPlugin::get_instance();
+        } catch ( Exception $e ) {
+            if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+                error_log( 'Failed to load StarmusPlugin: ' . $e->getMessage() );
+            }
+        }
+    }
+
+    public function init(): void {
+        $this->starmus_plugin->init();
+    }
+
+    public static function activate(): void {
+        flush_rewrite_rules();
+    }
+
+    public static function deactivate(): void {
+        flush_rewrite_rules();
+    }
+
+    /**
+     * WARNING: This is a destructive operation.
+     * Deletes all data associated with this plugin.
+     */
+    public static function uninstall(): void {
+        require_once STARMUS_PATH . 'src/admin/StarmusAdmin.php';
+
+        $cpt_slug = 'starmus_submission';
+        if ( class_exists( '\\Starisian\\src\\admin\\StarmusAdminSettings' ) ) {
+            $cpt_slug = \Starisian\src\admin\StarmusAdminSettings::get_option( 'cpt_slug', $cpt_slug );
+        }
+
+        delete_option( 'starmus_settings' );
+
+        $posts = get_posts(
+            [
+                'post_type'   => $cpt_slug,
+                'numberposts' => -1,
+                'post_status' => 'any',
+            ]
+        );
+
+        foreach ( $posts as $post ) {
+            wp_delete_post( $post->ID, true );
+        }
+    }
+
+    private function check_compatibility(): bool {
+        if ( version_compare( PHP_VERSION, self::MINIMUM_PHP_VERSION, '<' ) ) {
+            $this->compatibility_messages[] = sprintf(
+                __( 'Starmus Audio Recorder requires PHP %1$s or higher. You are running %2$s.', 'starmus-audio-recorder' ),
+                self::MINIMUM_PHP_VERSION,
+                PHP_VERSION
+            );
+        }
+
+        if ( version_compare( get_bloginfo( 'version' ), self::MINIMUM_WP_VERSION, '<' ) ) {
+            $this->compatibility_messages[] = sprintf(
+                __( 'Starmus Audio Recorder requires WordPress %1$s or higher. You are running %2$s.', 'starmus-audio-recorder' ),
+                self::MINIMUM_WP_VERSION,
+                get_bloginfo( 'version' )
+            );
+        }
+
+        return empty( $this->compatibility_messages );
+    }
+
+    public function display_compatibility_notice(): void {
+        foreach ( $this->compatibility_messages as $message ) {
+            echo '<div class="notice notice-error"><p>' . esc_html( $message ) . '</p></div>';
+        }
+    }
+
+    private function __clone() {}
+
+    public function __wakeup(): void {
+        $this->check_compatibility();
+    }
+}

--- a/src/includes/StarmusPlugin.php
+++ b/src/includes/StarmusPlugin.php
@@ -33,7 +33,7 @@ class StarmusPlugin {
 
     public function init() {
         // load custom post types
-        require_once STARMUS_PATH . 'src/include/StarmusCustomPostType.php';
+        require_once STARMUS_PATH . 'src/includes/StarmusCustomPostType.php';
         // if admin
         if ( is_admin() ) {
             new StarmusAdminSettings();

--- a/starmus-audio-recorder.php
+++ b/starmus-audio-recorder.php
@@ -4,12 +4,12 @@
  * © 2023–2025 Starisian Technologies. All Rights Reserved.
  *
  * NOTICE: All information contained herein is, and remains, the property of Starisian Technologies and its suppliers, if any.
- * The intellectual and technical concepts contained herein are proprietary to Starisian Technologies and its suppliers and may be covered by U.S.
- * and foreign patents, patents in process, and are protected by trade secret or copyright law.
+ * The intellectual and technical concepts contained herein are proprietary to Starisian Technologies and its suppliers and may
+ * be covered by U.S. and foreign patents, patents in process, and are protected by trade secret or copyright law.
  *
  * Dissemination of this information or reproduction of this material is strictly forbidden unless
  * prior written permission is obtained from Starisian Technologies.
- * 
+ *
  * SPDX-License-Identifier:  LicenseRef-Starisian-Technologies-Proprietary
  * License URI:              https://github.com/Starisian-Technologies/starmus-audio-recorder/LICENSE.md
  */
@@ -32,155 +32,23 @@ use Starisian\src\Autoloader;
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 
-
-// 1. DEFINE CONSTANTS
+// Define plugin constants.
 define( 'STARMUS_PATH', plugin_dir_path( __FILE__ ) );
 define( 'STARMUS_URL', plugin_dir_url( __FILE__ ) );
-define( 'STARMUS_VERSION', '0.3.1' ); // Or your get_file_data logic
+define( 'STARMUS_VERSION', '0.3.1' );
+define( 'STARMUS_MAIN_FILE', __FILE__ );
 
-// Load Composer autoloader if present
+// Register custom autoloader.
+require_once STARMUS_PATH . 'src/Autoloader.php';
+Autoloader::register();
+
+// Load Composer autoloader if present.
 if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
-    require_once __DIR__ . '/vendor/autoload.php';
+    require __DIR__ . '/vendor/autoload.php';
 }
 
-// This file contains all add_action('init', ...) calls for CPTs and Taxonomies.
-require_once STARMUS_PATH . 'src/includes/StarmusCustomPostType.php';
-
-
-use Starisian\src\includes\StarmusPlugin;
-
-final class StarmusAudioRecorder {
-    
-    // --- FIX: DEFINE MISSING CONSTANTS AND PROPERTIES ---
-    const MINIMUM_PHP_VERSION = '8.2';
-    const MINIMUM_WP_VERSION = '6.4';
-    private static $instance = null;
-	private StarmusPlugin $starmus_plugin;
-    private $compatibility_messages = [];
-
-	private function __construct() {
-		if ( ! $this->check_compatibility() ) {
-			add_action( 'admin_notices', [ $this, 'display_compatibility_notice' ] );
-			return;
-		}
-        
-        // Initialize the loader
-        $this->load_starmus_plugin();
-    }
-
-	public static function get_instance(): StarmusAudioRecorder {
-		if ( null === self::$instance ) {
-			self::$instance = new self();
-		}
-		return self::$instance;
-	}
-
-	private function load_starmus_plugin(): void {
-		if(!class_exists('StarmusPlugin')){
-			require_once STARMUS_PATH . 'src/includes/StarmusPlugin.php';
-		}
-		try{
-			$this->starmus_plugin = StarmusPlugin::get_instance();
-		}catch(Exception $e){
-			if(defined('WP_DEBUG') && WP_DEBUG){
-				error_log('Failed to load StarmusPlugin: ' . $e->getMessage());
-			}
-		}
-		return;
-	}
-
-        public function init(): void {
-                StarmusPlugin::get_instance()->init();
-        }
-
-        public function get_starmus_plugin(): StarmusPlugin {
-                return $this->starmus_plugin;
-        }
-
-	/**
-	 * FIX: Activation callback. ONLY flush rewrite rules.
-	 */
-	public static function activate(): void {
-		// The CPTs will be registered via the 'init' hook in post-types.php.
-        // We just need to flush the rules so WordPress recognizes their URLs.
-		flush_rewrite_rules();
-	}
-
-	/**
-	 * FIX: Deactivation callback. Should generally be empty unless you need to reverse a specific activation step.
-	 */
-	public static function deactivate(): void {
-		// No action needed. CPTs will disappear because the plugin's code won't run.
-		flush_rewrite_rules();
-	}
-
-	/**
-	 * WARNING: This is a destructive operation.
-	 * It deletes all data associated with this plugin.
-	 */
-        public static function uninstall(): void {
-        // You might want to keep this, but be aware of the consequences.
-                require_once STARMUS_PATH . 'src/admin/StarmusAdmin.php';
-
-                $cpt_slug = 'starmus_submission';
-                if ( class_exists( '\\Starisian\\src\\admin\\StarmusAdminSettings' ) ) {
-                        $cpt_slug = \Starisian\src\admin\StarmusAdminSettings::get_option( 'cpt_slug', $cpt_slug );
-                }
-
-                delete_option( 'starmus_settings' ); // Ensure this option name is correct
-
-                $posts = get_posts( [
-                        'post_type'   => $cpt_slug,
-                        'numberposts' => -1,
-                        'post_status' => 'any'
-                ] );
-
-                foreach ( $posts as $post ) {
-                        wp_delete_post( $post->ID, true );
-                }
-        }
-    
-    private function check_compatibility(): bool {
-        if ( version_compare( PHP_VERSION, self::MINIMUM_PHP_VERSION, '<' ) ) {
-            $this->compatibility_messages[] = sprintf(
-                __( 'Starmus Audio Recorder requires PHP %1$s or higher. You are running %2$s.', 'starmus-audio-recorder' ),
-                self::MINIMUM_PHP_VERSION,
-                PHP_VERSION
-            );
-        }
-
-        if ( version_compare( get_bloginfo( 'version' ), self::MINIMUM_WP_VERSION, '<' ) ) {
-            $this->compatibility_messages[] = sprintf(
-                __( 'Starmus Audio Recorder requires WordPress %1$s or higher. You are running %2$s.', 'starmus-audio-recorder' ),
-                self::MINIMUM_WP_VERSION,
-                get_bloginfo( 'version' )
-            );
-        }
-
-        return empty( $this->compatibility_messages );
-    }
-
-    public function display_compatibility_notice(): void {
-        foreach ( $this->compatibility_messages as $message ) {
-            echo '<div class="notice notice-error"><p>' . esc_html( $message ) . '</p></div>';
-        }
-    }
-
-    private function __clone() {}
-
-    public function __wakeup() {
-        $this->check_compatibility();
-    }
-}
-
-// Register plugin lifecycle hooks.
-register_activation_hook( __FILE__, [ 'StarmusAudioRecorder', 'activate' ] );
-register_deactivation_hook( __FILE__, [ 'StarmusAudioRecorder', 'deactivate' ] );
-register_uninstall_hook( __FILE__, [ 'StarmusAudioRecorder', 'uninstall' ] );
-
-// Initialize the plugin.
-add_action( 'plugins_loaded', [ 'StarmusAudioRecorder', 'get_instance' ] );
-add_action( 'init', [ StarmusAudioRecorder::get_instance(), 'init' ] );
+// Bootstrap the plugin.
+new \Starisian\Starmus\Plugin();


### PR DESCRIPTION
## Summary
- refactor plugin bootstrap to load autoloader and instantiate main Plugin class
- add `Starisian\Starmus\Plugin` orchestrator and expand autoloader for new namespace
- fix custom post type include path and composer namespace mapping

## Testing
- `composer lint:php` *(fails: vendor/bin/phpcs not found)*
- `composer test:php` *(fails: vendor/bin/phpunit not found)*
- `php -l starmus-audio-recorder.php src/Plugin.php src/Autoloader.php src/includes/StarmusPlugin.php`


------
https://chatgpt.com/codex/tasks/task_e_68ac95f91b5c8332a714a53dc1362c1e