### PR TITLE
Potential fix for code scanning alert no. 21: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint-only.yml
+++ b/.github/workflows/lint-only.yml
@@ -1,6 +1,8 @@
 # .github/workflows/lint.yml
 
 name: PHP Code Quality Check
+permissions:
+  contents: read
 
 # 1. TRIGGER: Run on pushes and pull requests to main branches
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/Starisian-Technologies/starmus-audio-recorder/security/code-scanning/21](https://github.com/Starisian-Technologies/starmus-audio-recorder/security/code-scanning/21)

To address this issue, you should add an explicit `permissions` block either at the workflow level (top-level, applies to all jobs by default), or at the job level (inside `lint` job). Since there is only one job and it does not perform any write operations to the repository, the minimal permissions needed are `contents: read`. This restricts the GITHUB_TOKEN to only allow read access to repository contents for the duration of the workflow, adhering to the principle of least privilege. The best fix is to insert the following block immediately after the `name: PHP Code Quality Check` line, making the permissions apply globally to all jobs:

```yaml
permissions:
  contents: read
```
No new imports, packages, or extra code changes are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
