### PR TITLE
Handle failed chunk read

### DIFF
--- a/src/frontend/StarmusAudioRecorderUI.php
+++ b/src/frontend/StarmusAudioRecorderUI.php
@@ -181,6 +181,11 @@ class StarmusAudioRecorderUI
 
         // 3. Append Chunk to Temporary File
         $chunk_content = file_get_contents($file_chunk['tmp_name']);
+
+        if (false === $chunk_content) {
+            wp_send_json_error(['message' => esc_html__('Server error: Could not read uploaded chunk.', 'starmus_audio_recorder')], 500);
+        }
+
         if (false === file_put_contents($temp_file_path, $chunk_content, FILE_APPEND)) {
             wp_send_json_error(['message' => esc_html__('Server error: Could not write chunk to disk.', 'starmus_audio_recorder')], 500);
         }


### PR DESCRIPTION
## Summary
- check chunk read result before writing to temp file

## Testing
- `composer lint:php` *(fails: vendor/bin/phpcs not found)*
- `composer analyze:php` *(fails: vendor/bin/phpstan not found)*
- `composer test:php` *(fails: vendor/bin/phpunit not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad123f2b388332b3a5b8bb91e20d29