### PR TITLE
Escape title output in recordings list

### DIFF
--- a/src/frontend/StarmusAudioRecorderUI.php
+++ b/src/frontend/StarmusAudioRecorderUI.php
@@ -64,7 +64,7 @@ class StarmusAudioRecorderUI
             $edit_link     = add_query_arg('post_id', get_the_ID(), $edit_page_url);
 ?>
             <div class="starmus-recording-item">
-                <h4><?php the_title(); ?></h4>
+                <h4><?php echo esc_html( get_the_title() ); ?></h4>
                 <p><em><?php echo esc_html(get_the_date()); ?> (<?php echo esc_html__('Status:', 'starmus_audio_recorder'); ?> <?php echo esc_html(get_post_status()); ?>)</em></p>
                 <?php if ($audio_url) : ?>
                     <audio controls src="<?php echo esc_url($audio_url); ?>"></audio>


### PR DESCRIPTION
## Summary
- sanitize post titles in the recordings list

## Testing
- `composer install` *(fails: CONNECT tunnel failed, response 403)*
- `composer lint:php` *(fails: vendor/bin/phpcs: not found)*
- `composer analyze:php` *(fails: vendor/bin/phpstan: not found)*
- `composer test:php` *(fails: vendor/bin/phpunit: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad124595fc833298638f850f8d59d7