### PR TITLE
Fix plugin initialization method references

### DIFF
--- a/starmus-audio-recorder.php
+++ b/starmus-audio-recorder.php
@@ -62,16 +62,16 @@ register_deactivation_hook( STARMUS_MAIN_FILE, array( 'Starmus\includes\StarmusP
 
 // Initialize the plugin.
 add_action(
-	'plugins_loaded',
-	function () {
-		\Starmus\includes\StarmusPlugin::starmus_run();
-	}
+        'plugins_loaded',
+        function () {
+                \Starmus\includes\StarmusPlugin::run();
+        }
 );
 
 // Hook the init method to the WordPress init action.
 add_action(
-	'init',
-	function () {
-		\Starmus\includes\StarmusPlugin::get_instance()->starmus_init();
-	}
+        'init',
+        function () {
+                \Starmus\includes\StarmusPlugin::get_instance()->init();
+        }
 );

--- a/tests/unit/StarmusPluginTest.php
+++ b/tests/unit/StarmusPluginTest.php
@@ -22,6 +22,6 @@ final class StarmusPluginTest extends TestCase
 
         // You might want to mock dependencies later
         $this->expectNotToPerformAssertions();
-        $plugin->starmus_init();
+        $plugin->init();
     }
 }


### PR DESCRIPTION
## Summary
- call plugin singleton run/init methods correctly to prevent runtime errors during load
- align unit test with updated init method

## Testing
- `composer run-script test:php` *(fails: vendor/bin/phpunit not found)*
- `npm run lint:js` *(fails: Cannot find module './shared/translate-cli-options')*
- `npm run lint:css` *(fails: Cannot find module 'ajv/dist/runtime/equal')*

------
https://chatgpt.com/codex/tasks/task_e_68b39fa32234833298eb3132c7fc4935