### PR TITLE
Potential fix for code scanning alert no. 37: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: Tests
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/Starisian-Technologies/starmus-audio-recorder/security/code-scanning/37](https://github.com/Starisian-Technologies/starmus-audio-recorder/security/code-scanning/37)

To fix this issue, add a `permissions` block at the root of the workflow file (`.github/workflows/test.yml`). This will apply least-privilege permissions (`contents: read`) to all jobs in the workflow, unless overridden by a more specific job-level permissions block. Insert the following lines after the workflow `name:` definition, and before the `on:` trigger. This does not affect workflow functionality, as none of the jobs require elevated GITHUB_TOKEN permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
