### PR TITLE
Potential fix for code scanning alert no. 29: Unsafe HTML constructed from library input

### DIFF
--- a/assets/js/starmus-audio-recorder-module.js
+++ b/assets/js/starmus-audio-recorder-module.js
@@ -221,10 +221,16 @@
 
         /**
          * Dynamically creates the recorder's HTML UI inside its designated container.
-         * @param {string} instanceId The ID of the instance whose UI should be created.
+         * @param {string} instanceId The ID of the instance whose UI should be created. Must be alphanumeric/underscore/dash.
          * @returns {void}
-         */
+         * @throws Will abort if the instanceId contains unsafe characters.
         setupUI: function(instanceId) {
+            // Only allow safe HTML ID characters: a-zA-Z0-9_- (no spaces, punctuation)
+            if (!/^[a-zA-Z0-9_-]+$/.test(instanceId)) {
+                secureLog('error', 'Unsafe instanceId value rejected by setupUI:', instanceId);
+                return;
+            }
+
             var container = document.getElementById('starmus_recorder_container_' + instanceId);
             if (!container) return;
 


### PR DESCRIPTION
Potential fix for [https://github.com/Starisian-Technologies/starmus-audio-recorder/security/code-scanning/29](https://github.com/Starisian-Technologies/starmus-audio-recorder/security/code-scanning/29)

To fix the problem, we should ensure that unsafe HTML cannot be injected via the `instanceId`, which is passed from library input and interpolated into HTML string literals. There are two main approaches:

1. **Strictly Validate/Sanitize `instanceId`** before use, restricting values to a safe pattern (e.g., only `[a-zA-Z0-9_-]`).
2. **Escape or Sanitize on Output:** Escaping or sanitizing the value when interpolating into HTML output, ensuring that even if bad values slip through, they cannot break out of attribute boundaries or inject tags/scripts.

The best fix in this case is to strictly sanitize the `instanceId` before it is used in any HTML interpolation. We can do this within `setupUI`, using a simple regex that only permits safe characters (e.g., `^[a-zA-Z0-9_\-]+$`). If the value does not match, abort and log an error message.

**Edits required:**
- In `setupUI` (line 227+), sanitize the `instanceId` variable at the outset:  
  - If the value does not match (allowing only alphanumeric, underscore, and dash, commonly used in HTML IDs), abort safely.
  - Optionally, document the function with a note about what characters are allowed for `instanceId` and why.

No external dependency is required—use a regex inline.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
