### PR TITLE
feat: allow page selection for recorder assets

### DIFF
--- a/src/admin/StarmusAdmin.php
+++ b/src/admin/StarmusAdmin.php
@@ -20,10 +20,14 @@ use Starmus\includes\StarmusSettings;
  */
 class StarmusAdmin {
 
-	const STAR_MENU_SLUG      = 'starmus-admin';
-	const STAR_SETTINGS_GROUP = 'starmus_settings_group';
+        /** Menu slug for the plugin settings page. */
+        const STAR_MENU_SLUG = 'starmus-admin';
 
-	private array $field_types = array();
+        /** Settings group identifier for WordPress options API. */
+        const STAR_SETTINGS_GROUP = 'starmus_settings_group';
+
+        /** Mapping of option keys to field types. */
+        private array $field_types = array();
 
 	/**
 	 * Constructor - initializes admin settings.
@@ -31,15 +35,17 @@ class StarmusAdmin {
 	 * @since 0.3.1
 	 */
 	public function __construct() {
-		$this->field_types = array(
-			'cpt_slug'           => 'text',
-			'file_size_limit'    => 'number',
-			'allowed_file_types' => 'textarea',
-			'consent_message'    => 'textarea',
-			'collect_ip_ua'      => 'checkbox',
-			'edit_page_id'       => 'pages_dropdown',
-		);
-	}
+                $this->field_types = array(
+                        'cpt_slug'              => 'text',
+                        'file_size_limit'       => 'number',
+                        'allowed_file_types'    => 'textarea',
+                        'consent_message'       => 'textarea',
+                        'collect_ip_ua'         => 'checkbox',
+                        'edit_page_id'          => 'pages_dropdown',
+                        'recorder_page_id'      => 'pages_dropdown',
+                        'my_recordings_page_id' => 'pages_dropdown',
+                );
+        }
 
 	/**
 	 * Add admin menu with error handling.
@@ -131,13 +137,20 @@ class StarmusAdmin {
 			self::STAR_MENU_SLUG
 		);
 
-		add_settings_section(
-			'starmus_privacy_section',
-			__( 'Privacy & Form Settings', STARMUS_TEXT_DOMAIN ),
-			null,
-			self::STAR_MENU_SLUG
-		);
-	}
+                add_settings_section(
+                        'starmus_privacy_section',
+                        __( 'Privacy & Form Settings', STARMUS_TEXT_DOMAIN ),
+                        null,
+                        self::STAR_MENU_SLUG
+                );
+
+                add_settings_section(
+                        'starmus_page_section',
+                        __( 'Frontend Page Settings', STARMUS_TEXT_DOMAIN ),
+                        null,
+                        self::STAR_MENU_SLUG
+                );
+        }
 
 	/**
 	 * Add settings fields.
@@ -159,23 +172,33 @@ class StarmusAdmin {
 				'section'     => 'starmus_rules_section',
 				'description' => __( 'Comma-separated list of allowed extensions.', STARMUS_TEXT_DOMAIN ),
 			),
-			'consent_message'    => array(
-				'title'       => __( 'Consent Checkbox Message', STARMUS_TEXT_DOMAIN ),
-				'section'     => 'starmus_privacy_section',
-				'description' => __( 'Text displayed next to consent checkbox.', STARMUS_TEXT_DOMAIN ),
-			),
-			'collect_ip_ua'      => array(
-				'title'       => __( 'Store IP & User Agent', STARMUS_TEXT_DOMAIN ),
-				'section'     => 'starmus_privacy_section',
-				'label'       => __( 'Save submitter IP and user agent.', STARMUS_TEXT_DOMAIN ),
-				'description' => __( 'Requires user consent.', STARMUS_TEXT_DOMAIN ),
-			),
-			'edit_page_id'       => array(
-				'title'       => __( 'Edit Page', STARMUS_TEXT_DOMAIN ),
-				'section'     => 'starmus_privacy_section',
-				'description' => __( 'Page containing the audio editor shortcode.', STARMUS_TEXT_DOMAIN ),
-			),
-		);
+                        'consent_message'    => array(
+                                'title'       => __( 'Consent Checkbox Message', STARMUS_TEXT_DOMAIN ),
+                                'section'     => 'starmus_privacy_section',
+                                'description' => __( 'Text displayed next to consent checkbox.', STARMUS_TEXT_DOMAIN ),
+                        ),
+                        'collect_ip_ua'      => array(
+                                'title'       => __( 'Store IP & User Agent', STARMUS_TEXT_DOMAIN ),
+                                'section'     => 'starmus_privacy_section',
+                                'label'       => __( 'Save submitter IP and user agent.', STARMUS_TEXT_DOMAIN ),
+                                'description' => __( 'Requires user consent.', STARMUS_TEXT_DOMAIN ),
+                        ),
+                        'edit_page_id'       => array(
+                                'title'       => __( 'Edit Page', STARMUS_TEXT_DOMAIN ),
+                                'section'     => 'starmus_page_section',
+                                'description' => __( 'Page containing the audio editor shortcode.', STARMUS_TEXT_DOMAIN ),
+                        ),
+                        'recorder_page_id'   => array(
+                                'title'       => __( 'Recorder Page', STARMUS_TEXT_DOMAIN ),
+                                'section'     => 'starmus_page_section',
+                                'description' => __( 'Page containing the [starmus-audio-recorder] shortcode.', STARMUS_TEXT_DOMAIN ),
+                        ),
+                        'my_recordings_page_id' => array(
+                                'title'       => __( 'My Recordings Page', STARMUS_TEXT_DOMAIN ),
+                                'section'     => 'starmus_page_section',
+                                'description' => __( 'Page containing the [starmus-my-recordings] shortcode.', STARMUS_TEXT_DOMAIN ),
+                        ),
+                );
 
 		foreach ( $fields as $id => $field ) {
 			add_settings_field(
@@ -230,12 +253,20 @@ class StarmusAdmin {
 		// Collect IP/UA
 		$sanitized['collect_ip_ua'] = ! empty( $input['collect_ip_ua'] ) ? 1 : 0;
 
-		// Edit page ID
-		$page_id                   = absint( $input['edit_page_id'] ?? 0 );
-		$sanitized['edit_page_id'] = ( $page_id > 0 && get_post( $page_id ) ) ? $page_id : 0;
+                // Edit page ID
+                $page_id                   = absint( $input['edit_page_id'] ?? 0 );
+                $sanitized['edit_page_id'] = ( $page_id > 0 && get_post( $page_id ) ) ? $page_id : 0;
 
-		return $sanitized;
-	}
+                // Recorder page ID
+                $page_id                        = absint( $input['recorder_page_id'] ?? 0 );
+                $sanitized['recorder_page_id']  = ( $page_id > 0 && get_post( $page_id ) ) ? $page_id : 0;
+
+                // My Recordings page ID
+                $page_id                            = absint( $input['my_recordings_page_id'] ?? 0 );
+                $sanitized['my_recordings_page_id'] = ( $page_id > 0 && get_post( $page_id ) ) ? $page_id : 0;
+
+                return $sanitized;
+        }
 
 	/**
 	 * Validate file extension.

--- a/src/includes/StarmusSettings.php
+++ b/src/includes/StarmusSettings.php
@@ -15,10 +15,26 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 final class StarmusSettings {
 
-	public const STAR_OPTION_KEY = 'starmus_options';
+        /**
+         * Option key used to store plugin settings.
+         *
+         * @var string
+         */
+        public const STAR_OPTION_KEY = 'starmus_options';
 
-	private static ?array $star_cache         = null;
-	private static ?array $star_default_cache = null;
+        /**
+         * Cached plugin settings for the current request.
+         *
+         * @var array|null
+         */
+        private static ?array $star_cache = null;
+
+        /**
+         * Cached default settings to avoid repeated computation.
+         *
+         * @var array|null
+         */
+        private static ?array $star_default_cache = null;
 
 	/**
 	 * Get a single setting with caching.
@@ -90,9 +106,11 @@ final class StarmusSettings {
 				'recording_time_limit' => 300,
 				'allowed_file_types'   => 'mp3,wav,webm,m4a,ogg,opus',
 				'consent_message'      => __( 'I consent to having this audio recording stored and used.', STARMUS_TEXT_DOMAIN ),
-				'collect_ip_ua'        => 0,
-				'data_policy_url'      => '',
-				'edit_page_id'         => 0,
+                                'collect_ip_ua'        => 0,
+                                'data_policy_url'      => '',
+                                'edit_page_id'         => 0,
+                                'recorder_page_id'     => 0,
+                                'my_recordings_page_id'=> 0,
 			);
 			self::$star_default_cache = apply_filters( 'starmus_default_settings', self::$star_default_cache );
 		}
@@ -129,11 +147,13 @@ final class StarmusSettings {
 		switch ( $key ) {
 			case 'cpt_slug':
 				return sanitize_key( $value );
-			case 'file_size_limit':
-			case 'recording_time_limit':
-			case 'collect_ip_ua':
-			case 'edit_page_id':
-				return absint( $value );
+                        case 'file_size_limit':
+                        case 'recording_time_limit':
+                        case 'collect_ip_ua':
+                        case 'edit_page_id':
+                        case 'recorder_page_id':
+                        case 'my_recordings_page_id':
+                                return absint( $value );
 			case 'allowed_file_types':
 				return sanitize_text_field( $value );
 			case 'consent_message':


### PR DESCRIPTION
## Summary
- add recorder and my recordings page selectors to admin
- defer-load recorder scripts when page settings incomplete
- document constants and methods across settings, admin, and UI

## Testing
- `composer run lint:php` *(fails: vendor/bin/phpcs not found)*
- `composer run analyze:php` *(fails: vendor/bin/phpstan not found)*
- `composer run test:php` *(fails: vendor/bin/phpunit not found)*


------
https://chatgpt.com/codex/tasks/task_e_68bb149f61708332972b9b3096163528