### PR TITLE
Potential fix for code scanning alert no. 56: Log injection

### DIFF
--- a/scripts/fetch-phpdoc.cjs
+++ b/scripts/fetch-phpdoc.cjs
@@ -12,7 +12,11 @@ function download(url) {
     if (res.statusCode!==200){console.error('Download failed:',res.statusCode);process.exit(1);}
     const out=fs.createWriteStream(dest); 
     res.pipe(out).on('finish',()=>{fs.chmodSync(dest,0o755);console.log('phpDocumentor.phar ready');});
-  }).on('error',e=>{console.error(e);process.exit(1);});
+  }).on('error',e=>{
+    const errMsg = (e && e.message ? e.message : String(e)).replace(/[\r\n]+/g, ' ');
+    console.error('Download error:', errMsg);
+    process.exit(1);
+  });
 }
 
 download('https://phpdoc.org/phpDocumentor.phar');


### PR DESCRIPTION
Potential fix for [https://github.com/Starisian-Technologies/starmus-audio-recorder/security/code-scanning/56](https://github.com/Starisian-Technologies/starmus-audio-recorder/security/code-scanning/56)

To fix this issue, we need to sanitize user-controlled data before it is logged. Here, the error object `e` can contain (directly or via its properties, e.g., `e.message`) attacker-controlled data. Before logging, we should remove newline (`\n`), carriage return (`\r`), and other potentially log-forging characters from the message.

The best approach is:
- Replace logging of the entire error object with explicit logging of its message, after sanitizing it (e.g., via `.replace(/\r?\n/g, '')`).
- If `e.message` is not present, fallback to logging a stringified version of `e`, similarly sanitized.
- This change is localized to line 15.

We do not need external libraries; only built-in string manipulation methods will suffice.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
