### PR TITLE
Sanitize recorder submissions and improve UI accessibility

### DIFF
--- a/src/templates/starmus-audio-recorder-ui.php
+++ b/src/templates/starmus-audio-recorder-ui.php
@@ -17,17 +17,7 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly.
-}
-// Add missing global functions for direct template use
-if ( ! function_exists( 'esc_attr' ) ) {
-	function esc_attr( $text ) { return htmlspecialchars( $text, ENT_QUOTES, 'UTF-8' ); }
-}
-if ( ! function_exists( 'current_user_can' ) ) {
-	function current_user_can( $cap ) {
-		// Fallback: Only allow for logged-in users in non-WP context
-		return isset( $_COOKIE['wordpress_logged_in'] );
-	}
+        exit; // Exit if accessed directly.
 }
 
 // ** CRITICAL **
@@ -114,7 +104,7 @@ $is_admin              = current_user_can( 'manage_options' );
 					<label for="starmus_consent_<?php echo esc_attr( $instance_id ); ?>">
 						<?php echo wp_kses_post( $consent_message ); ?>
 						<?php if ( ! empty( $data_policy_url ) ) : ?>
-							<a href="<?php echo esc_url( $data_policy_url ); ?>" target="_blank" rel="noopener"><?php esc_html_e( 'Privacy Policy', 'starmus-audio-recorder' ); ?></a>
+                                                        <a href="<?php echo esc_url( $data_policy_url ); ?>" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Privacy Policy', 'starmus-audio-recorder' ); ?></a>
 						<?php endif; ?>
 					</label>
 				</div>
@@ -181,26 +171,31 @@ $is_admin              = current_user_can( 'manage_options' );
 			</button>
 			<?php
 			// Show 'Upload audio' link for Authors and above
-			if ( current_user_can( 'author' ) || current_user_can( 'editor' ) || current_user_can( 'administrator' ) ) : ?>
-				<div class="starmus-upload-audio-link" style="margin-top:24px;text-align:right;">
-					<a href="#" id="starmus_show_upload_<?php echo esc_attr( $instance_id ); ?>" style="font-size:0.95em;">Upload audio</a>
-				</div>
-				<div id="starmus_manual_upload_wrap_<?php echo esc_attr( $instance_id ); ?>" style="display:none;margin-top:12px;">
-					<label for="starmus_manual_upload_input_<?php echo esc_attr( $instance_id ); ?>">Select audio file to upload:</label>
-					<input type="file" id="starmus_manual_upload_input_<?php echo esc_attr( $instance_id ); ?>" name="audio_file" accept="audio/*">
-				</div>
-				<script>
-				document.addEventListener('DOMContentLoaded', function() {
-					var link = document.getElementById('starmus_show_upload_<?php echo esc_attr( $instance_id ); ?>');
-					var wrap = document.getElementById('starmus_manual_upload_wrap_<?php echo esc_attr( $instance_id ); ?>');
-					if (link && wrap) {
-						link.addEventListener('click', function(e) {
-							e.preventDefault();
-							wrap.style.display = (wrap.style.display === 'none') ? 'block' : 'none';
-						});
-					}
-				});
-				</script>
+                        if ( current_user_can( 'author' ) || current_user_can( 'editor' ) || current_user_can( 'administrator' ) ) : ?>
+                                <div class="starmus-upload-audio-link" style="margin-top:24px;text-align:right;">
+                                        <button type="button" id="starmus_show_upload_<?php echo esc_attr( $instance_id ); ?>" class="starmus-btn starmus-btn--link" aria-controls="starmus_manual_upload_wrap_<?php echo esc_attr( $instance_id ); ?>" aria-expanded="false" style="font-size:0.95em;">
+                                                <?php esc_html_e( 'Upload audio', 'starmus-audio-recorder' ); ?>
+                                        </button>
+                                </div>
+                                <div id="starmus_manual_upload_wrap_<?php echo esc_attr( $instance_id ); ?>" style="display:none;margin-top:12px;">
+                                        <label for="starmus_manual_upload_input_<?php echo esc_attr( $instance_id ); ?>">Select audio file to upload:</label>
+                                        <input type="file" id="starmus_manual_upload_input_<?php echo esc_attr( $instance_id ); ?>" name="audio_file" accept="audio/*">
+                                </div>
+                                <script>
+                                document.addEventListener('DOMContentLoaded', function() {
+                                        const instanceId = <?php echo wp_json_encode( $instance_id ); ?>;
+                                        const toggle = document.getElementById('starmus_show_upload_' + instanceId);
+                                        const wrapper = document.getElementById('starmus_manual_upload_wrap_' + instanceId);
+                                        if (toggle && wrapper) {
+                                                toggle.addEventListener('click', function(event) {
+                                                        event.preventDefault();
+                                                        const isHidden = wrapper.style.display === 'none' || wrapper.style.display === '';
+                                                        wrapper.style.display = isHidden ? 'block' : 'none';
+                                                        toggle.setAttribute('aria-expanded', isHidden ? 'true' : 'false');
+                                                });
+                                        }
+                                });
+                                </script>
 			<?php endif; ?>
 		</div>
 	</form>


### PR DESCRIPTION
## Summary
- replace the fallback upload toggle link with an accessible button that keeps aria state in sync and tighten the privacy link attributes in the recorder template
- harden upload handling by validating MIME types against a mapped whitelist, generating deterministic filenames, and sanitising all request data before persistence
- centralise submission sanitisation for metadata, taxonomy assignment, and draft creation while keeping audit logging intact

## Testing
- `php -l src/frontend/StarmusAudioRecorderUI.php`
- `php -l src/templates/starmus-audio-recorder-ui.php`
- `composer run lint` *(fails: vendor/bin/phpcs missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d5e90fb29483328be9b8f1ffe0060e