### PR TITLE
Fix REST upload handler wiring and document namespaces

### DIFF
--- a/src/frontend/StarmusAudioEditorUI.php
+++ b/src/frontend/StarmusAudioEditorUI.php
@@ -32,8 +32,8 @@ class StarmusAudioEditorUI
 
         /**
          * REST namespace consumed by the editor for annotation endpoints.
+         * Use StarmusSubmissionHandler::STAR_REST_NAMESPACE directly where needed.
          */
-        public const STAR_REST_NAMESPACE = StarmusSubmissionHandler::STAR_REST_NAMESPACE;
 
         /**
          * Upper bound for stored annotations to avoid overloading requests.

--- a/src/frontend/StarmusAudioRecorderUI.php
+++ b/src/frontend/StarmusAudioRecorderUI.php
@@ -1,12 +1,19 @@
 <?php
+
+/**
+ * Front-end presentation layer for the Starmus recorder experience.
+ *
+ * @package   Starmus
+ */
+
 namespace Starmus\frontend;
 
 if (!defined('ABSPATH')) {
-	exit;
+        exit;
 }
 
-use Starmus\includes\StarmusSettings;
 use Starmus\helpers\StarmusLogger;
+use Starmus\includes\StarmusSettings;
 
 /**
  * Renders the user interface for the audio recorder and recordings list.
@@ -16,24 +23,37 @@ use Starmus\helpers\StarmusLogger;
 class StarmusAudioRecorderUI
 {
 
-	public const STAR_REST_NAMESPACE = 'starmus/v1';
+        /**
+         * REST namespace exposed to localized front-end scripts.
+         */
+        public const STAR_REST_NAMESPACE = StarmusSubmissionHandler::STAR_REST_NAMESPACE;
 
-	private ?StarmusSettings $settings = null;
+        /**
+         * Optional settings container used to hydrate UI data.
+         */
+        private ?StarmusSettings $settings = null;
 
-	public function __construct(?StarmusSettings $settings)
-	{
-		$this->settings = $settings;
-		$this->register_hooks();
-	}
+        /**
+         * Prime the UI layer with optional settings for template hydration.
+         *
+         * @param StarmusSettings|null $settings Configuration object, if available.
+         */
+        public function __construct(?StarmusSettings $settings)
+        {
+                $this->settings = $settings;
+                $this->register_hooks();
+        }
 
 
-	/**
-	 * Register all WordPress hooks required for the front-end recorder UI.
-	 */
-	private function register_hooks(): void
-	{
-		add_shortcode('starmus_my_recordings', array($this, 'render_my_recordings_shortcode'));
-		add_shortcode('starmus_audio_recorder_form', array($this, 'render_recorder_shortcode'));
+        /**
+         * Register all WordPress hooks required for the front-end recorder UI.
+         *
+         * @return void
+         */
+        private function register_hooks(): void
+        {
+                add_shortcode('starmus_my_recordings', array($this, 'render_my_recordings_shortcode'));
+                add_shortcode('starmus_audio_recorder_form', array($this, 'render_recorder_shortcode'));
 
 		add_action('wp_enqueue_scripts', array($this, 'enqueue_scripts'));
 
@@ -47,10 +67,14 @@ class StarmusAudioRecorderUI
 		add_action('delete_recording-type', array($this, 'clear_taxonomy_transients'));
 	}
 
-	/**
-	 * Render the "My Recordings" shortcode.
-	 */
-	public function render_my_recordings_shortcode($atts = array()): string
+        /**
+         * Render the "My Recordings" shortcode.
+         *
+         * @param array $atts Shortcode attributes supplied by WordPress.
+         *
+         * @return string Rendered HTML for the recordings list.
+         */
+        public function render_my_recordings_shortcode($atts = array()): string
 	{
 		if (!is_user_logged_in()) {
 			return '<p>' . esc_html__('You must be logged in to view your recordings.', 'starmus-audio-recorder') . '</p>';
@@ -86,10 +110,14 @@ class StarmusAudioRecorderUI
 		}
 	}
 
-	/**
-	 * Renders the audio recorder shortcode by passing data to the template.
-	 */
-	public function render_recorder_shortcode($atts = array()): string
+        /**
+         * Render the recorder form shortcode output.
+         *
+         * @param array $atts Shortcode attributes supplied by WordPress.
+         *
+         * @return string Rendered HTML for the recorder UI.
+         */
+        public function render_recorder_shortcode($atts = array()): string
 	{
 		if (!is_user_logged_in()) {
 			return '<p>' . esc_html__('You must be logged in to record audio.', 'starmus-audio-recorder') . '</p>';
@@ -119,11 +147,12 @@ class StarmusAudioRecorderUI
 		}
 	}
 
-	/**
-	 * Registers and conditionally enqueues all frontend scripts and styles.
-	 * Mirrors your original debug/minified split and script localization.
-	 */
-	public function enqueue_scripts(): void
+        /**
+         * Register and localize front-end assets for the recorder UI.
+         *
+         * @return void
+         */
+        public function enqueue_scripts(): void
 	{
 		try {
 			if (is_admin()) {
@@ -173,7 +202,7 @@ class StarmusAudioRecorderUI
 					$script_handle,
 					'starmusFormData',
 					array(
-						'rest_url' => esc_url_raw(rest_url(self::STAR_REST_NAMESPACE . '/upload-chunk')),
+                                                'rest_url' => esc_url_raw(rest_url(StarmusSubmissionHandler::STAR_REST_NAMESPACE . '/upload-chunk')),
 						'rest_nonce' => wp_create_nonce('wp_rest'),
 					)
 				);
@@ -218,11 +247,16 @@ class StarmusAudioRecorderUI
 		}
 	}
 
-	/**
-	 * Render a template file with provided arguments.
-	 * Searches child theme, parent theme, then plugin (src/templates).
-	 */
-	private function render_template(string $template_file, array $args = array()): string
+        /**
+         * Render a template file with provided arguments.
+         * Searches child theme, parent theme, then plugin (src/templates).
+         *
+         * @param string $template_file Template filename to locate.
+         * @param array  $args          Context passed into the template scope.
+         *
+         * @return string Rendered HTML output from the template.
+         */
+        private function render_template(string $template_file, array $args = array()): string
 	{
 		try {
 			$template_name = basename($template_file);
@@ -259,10 +293,15 @@ class StarmusAudioRecorderUI
 		}
 	}
 
-	/**
-	 * Get cached terms for a taxonomy, with transient caching.
-	 */
-	private function get_cached_terms(string $taxonomy, string $cache_key): array
+        /**
+         * Get cached terms for a taxonomy, with transient caching.
+         *
+         * @param string $taxonomy  Taxonomy slug.
+         * @param string $cache_key Transient cache key for storing the terms.
+         *
+         * @return array List of taxonomy terms.
+         */
+        private function get_cached_terms(string $taxonomy, string $cache_key): array
 	{
 		$terms = get_transient($cache_key);
 		if (false === $terms) {
@@ -282,28 +321,34 @@ class StarmusAudioRecorderUI
 		return is_array($terms) ? $terms : array();
 	}
 
-	/**
-	 * Clear term caches for Language and Recording Type.
-	 */
-	public function clear_taxonomy_transients(): void
+        /**
+         * Clear term caches for Language and Recording Type.
+         *
+         * @return void
+         */
+        public function clear_taxonomy_transients(): void
 	{
 		delete_transient('starmus_languages_list');
 		delete_transient('starmus_recording_types_list');
 	}
 
-	/**
-	 * Admin edit screen for CPT list (kept for back-compat with your template usage).
-	 */
-	private function get_edit_page_url_admin(): string
+        /**
+         * Admin edit screen for CPT list (kept for back-compat with your template usage).
+         *
+         * @return string URL to the admin list table for recordings.
+         */
+        private function get_edit_page_url_admin(): string
 	{
 		$cpt = $this->settings ? $this->settings->get('cpt_slug', 'audio-recording') : 'audio-recording';
 		return admin_url('edit.php?post_type=' . $cpt);
 	}
 
-	/**
-	 * Front-end edit page URL (optional, preserved if your theme templates use it).
-	 */
-	private function get_edit_page_url(): string
+        /**
+         * Front-end edit page URL (optional, preserved if your theme templates use it).
+         *
+         * @return string URL to the front-end edit page or an empty string.
+         */
+        private function get_edit_page_url(): string
 	{
 		$edit_page_id = $this->settings ? $this->settings->get('edit_page_id') : 0;
 		if (!empty($edit_page_id)) {

--- a/src/frontend/StarmusRestHandler.php
+++ b/src/frontend/StarmusRestHandler.php
@@ -1,4 +1,11 @@
 <?php
+
+/**
+ * REST handler bridging HTTP endpoints to submission services.
+ *
+ * @package   Starmus
+ */
+
 namespace Starmus\frontend;
 
 if (!defined('ABSPATH')) {
@@ -7,21 +14,27 @@ if (!defined('ABSPATH')) {
 
 use Starmus\includes\StarmusSettings;
 use Starmus\helpers\StarmusLogger;
-use Starmus\helpers\StarmusSanitizer;
 use WP_Error;
 use WP_REST_Request;
 use WP_REST_Response;
 
 /**
- * REST API handler for Starmus audio submissions.
+ * Exposes WordPress REST API routes for audio submissions.
  *
- * Handles fallback uploads, chunked uploads, and submission status checks.
+ * Routes map directly to {@see StarmusSubmissionHandler} to keep logic in one place.
  */
 class StarmusRestHandler
 {
-
+    /**
+     * Submission service that performs all validation and storage work.
+     */
     private StarmusSubmissionHandler $submission_handler;
 
+    /**
+     * Build the handler and register the REST routes during boot.
+     *
+     * @param StarmusSettings $settings Plugin configuration wrapper.
+     */
     public function __construct(StarmusSettings $settings)
     {
         $this->submission_handler = new StarmusSubmissionHandler($settings);
@@ -30,36 +43,38 @@ class StarmusRestHandler
 
     /**
      * Register REST API routes.
+     *
+     * @return void
      */
     public function register_routes(): void
     {
         register_rest_route(
-            'starmus/v1',
+            StarmusSubmissionHandler::STAR_REST_NAMESPACE,
             '/upload-fallback',
             [
                 'methods' => 'POST',
                 'callback' => [$this, 'handle_fallback_upload'],
-                'permission_callback' => fn() => is_user_logged_in(),
+                'permission_callback' => static fn() => current_user_can('upload_files'),
             ]
         );
 
         register_rest_route(
-            'starmus/v1',
+            StarmusSubmissionHandler::STAR_REST_NAMESPACE,
             '/upload-chunk',
             [
                 'methods' => 'POST',
                 'callback' => [$this, 'handle_chunk_upload'],
-                'permission_callback' => fn() => is_user_logged_in(),
+                'permission_callback' => static fn() => current_user_can('upload_files'),
             ]
         );
 
         register_rest_route(
-            'starmus/v1',
+            StarmusSubmissionHandler::STAR_REST_NAMESPACE,
             '/status/(?P<id>\d+)',
             [
                 'methods' => 'GET',
                 'callback' => [$this, 'handle_status'],
-                'permission_callback' => fn() => is_user_logged_in(),
+                'permission_callback' => static fn() => current_user_can('upload_files'),
                 'args' => [
                     'id' => [
                         'validate_callback' => 'is_numeric',
@@ -71,21 +86,21 @@ class StarmusRestHandler
 
     /**
      * Handle fallback form-based upload.
+     *
+     * @param WP_REST_Request $request REST request containing the form payload.
+     *
+     * @return WP_REST_Response|WP_Error REST response or error wrapper.
      */
     public function handle_fallback_upload(WP_REST_Request $request): WP_REST_Response|WP_Error
     {
         try {
-            $files_data = $request->get_file_params();
-            $form_data = StarmusSanitizer::sanitize_submission_data($request->get_params());
-
-            $result = $this->submission_handler->process_fallback_upload($files_data, $form_data);
+            $result = $this->submission_handler->handle_fallback_upload_rest($request);
 
             if (is_wp_error($result)) {
                 return $result;
             }
 
             return new WP_REST_Response(['success' => true, 'data' => $result], 200);
-
         } catch (\Throwable $e) {
             StarmusLogger::log('RestHandler:fallback', $e);
             return new WP_Error('server_error', 'Upload failed', ['status' => 500]);
@@ -94,21 +109,21 @@ class StarmusRestHandler
 
     /**
      * Handle chunked uploads.
+     *
+     * @param WP_REST_Request $request REST request containing chunk data.
+     *
+     * @return WP_REST_Response|WP_Error REST response or error wrapper.
      */
     public function handle_chunk_upload(WP_REST_Request $request): WP_REST_Response|WP_Error
     {
         try {
-            $files_data = $request->get_file_params();
-            $form_data = StarmusSanitizer::sanitize_submission_data($request->get_params());
-
-            $result = $this->submission_handler->process_chunk_upload($files_data, $form_data);
+            $result = $this->submission_handler->handle_upload_chunk_rest($request);
 
             if (is_wp_error($result)) {
                 return $result;
             }
 
             return new WP_REST_Response(['success' => true, 'data' => $result], 200);
-
         } catch (\Throwable $e) {
             StarmusLogger::log('RestHandler:chunk', $e);
             return new WP_Error('server_error', 'Chunk upload failed', ['status' => 500]);
@@ -117,6 +132,10 @@ class StarmusRestHandler
 
     /**
      * Handle status check for a submission.
+     *
+     * @param WP_REST_Request $request REST request containing the submission ID.
+     *
+     * @return WP_REST_Response|WP_Error REST response or error wrapper.
      */
     public function handle_status(WP_REST_Request $request): WP_REST_Response|WP_Error
     {
@@ -139,7 +158,6 @@ class StarmusRestHandler
                 ],
                 200
             );
-
         } catch (\Throwable $e) {
             StarmusLogger::log('RestHandler:status', $e);
             return new WP_Error('server_error', 'Could not fetch status', ['status' => 500]);

--- a/tests/e2e/offline-queue.spec.js
+++ b/tests/e2e/offline-queue.spec.js
@@ -45,7 +45,7 @@ test.describe("Offline-first patterns", () => {
   });
 
   test("chunked upload with slow connection", async ({ page }) => {
-    await page.route("**/starmus/v1/upload-chunk", (route) => {
+    await page.route("**/star-starmus-audio-recorder/v1/upload-chunk", (route) => {
       setTimeout(() => route.continue(), 2000); // 2s delay
     });
 

--- a/tests/integration/RestApiTest.php
+++ b/tests/integration/RestApiTest.php
@@ -23,14 +23,14 @@ class RestApiTest extends WP_UnitTestCase {
     }
 
     public function test_rest_namespace_follows_star_convention() {
-        $namespace = \Starmus\frontend\StarmusAudioRecorderUI::STAR_REST_NAMESPACE;
-        $this->assertStringStartsWith('starmus/', $namespace);
+        $namespace = \Starmus\frontend\StarmusSubmissionHandler::STAR_REST_NAMESPACE;
+        $this->assertStringStartsWith('star-', $namespace);
     }
 
     public function test_upload_requires_authentication() {
         wp_set_current_user(0); // Logout
         
-        $request = new WP_REST_Request('POST', '/starmus/v1/upload-chunk');
+        $request = new WP_REST_Request('POST', '/star-starmus-audio-recorder/v1/upload-chunk');
         $response = $this->ui->upload_permissions_check($request);
         
         $this->assertFalse($response);
@@ -41,14 +41,14 @@ class RestApiTest extends WP_UnitTestCase {
         $user_id = $this->factory->user->create(['role' => 'subscriber']);
         wp_set_current_user($user_id);
         
-        $request = new WP_REST_Request('POST', '/starmus/v1/upload-chunk');
+        $request = new WP_REST_Request('POST', '/star-starmus-audio-recorder/v1/upload-chunk');
         $response = $this->ui->upload_permissions_check($request);
         
         $this->assertFalse($response);
     }
 
     public function test_upload_requires_valid_nonce() {
-        $request = new WP_REST_Request('POST', '/starmus/v1/upload-chunk');
+        $request = new WP_REST_Request('POST', '/star-starmus-audio-recorder/v1/upload-chunk');
         $request->set_header('X-WP-Nonce', 'invalid_nonce');
         
         $response = $this->ui->upload_permissions_check($request);


### PR DESCRIPTION
## Summary
- align REST handlers to use the submission service and enforce upload capabilities
- switch the REST namespace to star-starmus-audio-recorder/v1 across PHP, JS, and tests
- add documentation blocks for recorder and editor UI classes, constants, and methods

## Testing
- php -l src/frontend/StarmusRestHandler.php
- php -l src/frontend/StarmusSubmissionHandler.php
- php -l src/frontend/StarmusAudioRecorderUI.php
- php -l src/frontend/StarmusAudioEditorUI.php

------
https://chatgpt.com/codex/tasks/task_e_68d818f64d888332bffa63c66c7a9b6a